### PR TITLE
Fix to fatal error "Call to a member function getElementHook() on a non-object in candy.php"

### DIFF
--- a/app/views/candy.php
+++ b/app/views/candy.php
@@ -49,7 +49,7 @@ class CandyView extends ThemeView {
 			}
 		}
 
-		App::import('Vendor', 'HookContainer', array('file' => 'candycane' . DS . 'hook_container.php'));
+		ClassRegistry::getObject('HookContainer');
 		$hookContainer = new HookContainer();
 		if (is_file($file)) {
 			$params = array_merge_recursive($params, $this->loaded);


### PR DESCRIPTION
After pulling changes from master I get this error: …

Fatal error: Call to a member function getElementHook() on a non-object in C:\httpd\www\candy\app\views\candy.php on line 56

Now it works well
