### PR TITLE
Fixed non alphanumeric name can not save the issue status.

### DIFF
--- a/app/models/issue_status.php
+++ b/app/models/issue_status.php
@@ -80,7 +80,6 @@ class IssueStatus extends AppModel
       'validates_presence_of'=>array('rule'=>array('notEmpty')),
       'validates_uniqueness_of'=>array('rule'=>array('isUnique')),
       'validates_length_of'=>array('rule'=>array('maxLength', 30)),
-      'validates_format_of'=>array('rule'=>array('custom', '/\w+/'))
     ),
   );
 

--- a/app/tests/cases/models/issue_status.test.php
+++ b/app/tests/cases/models/issue_status.test.php
@@ -27,6 +27,10 @@ class IssueStatusTestCase extends CakeTestCase {
     $this->assertEqual(1, count($this->IssueStatus->validationErrors));
 
     $this->IssueStatus->create();
+    $this->IssueStatus->set(array('name' => "新規"));
+    $this->assertTrue($this->IssueStatus->save());
+
+    $this->IssueStatus->create();
     $this->IssueStatus->set(array('name' => "Test Status"));
     $this->assertTrue($this->IssueStatus->save());
     $this->IssueStatus->read(null, $this->IssueStatus->getLastInsertID());


### PR DESCRIPTION
新しいチケットのステータスの追加画面(issue_statuses/add)で、英数字を含まない名前をつけようとするとバリデーションではじかれてしまっていました。

例）
- 「あいうえお」-> NG
- 「あいうえおa」-> OK

英数字を含まない名前もつけられるようにしてみました。
