### PR TITLE
ユーザ新規追加時の規定言語修正

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -216,13 +216,15 @@ class UsersController extends AppController {
 			}
 		}
 
+		$Setting = ClassRegistry::getObject('Setting');
+
 		$user = $this->User->create(array(
 			'id' => '',
 			'login' => '',
 			'firstname' => '',
 			'lastname' => '',
 			'mail' => '',
-			'language' => '',
+			'language' => $Setting->default_language,
 			));
 		$this->set('user', $user);
 		# @auth_sources = AuthSource.find(:all)

--- a/app/View/Elements/users/form.ctp
+++ b/app/View/Elements/users/form.ctp
@@ -1,7 +1,6 @@
 <?php
 // @todo custom_field_values
 // @todo auth_sources
-// @todo selected current language
 ?>
 <!--[form:user]-->
 <div class="box">


### PR DESCRIPTION
管理者がユーザを新規追加する時に規定の言語がBrasilに必ずなっているのを、設定で選択した規定の言語がデフォルト状態で選択されるようにしました。
