### PR TITLE
MailerComponet::startup()の変数名の間違い

### DIFF
--- a/app/Controller/Component/MailerComponent.php
+++ b/app/Controller/Component/MailerComponent.php
@@ -3,7 +3,7 @@ App::uses('CakeEmail', 'Network/Email');
 
 class MailerComponent extends Component {
 
-	public function startup(Controller $controller) {
+	public function startup(Controller $Controller) {
 		$this->Controller = $Controller;
 
 		if (extension_loaded('mbstring')) {


### PR DESCRIPTION
MailerComponet::startup()のパラメータ$Controllerの一文字目が小文字になっていたので、チケットを表示するページで$Controllerが見つからないエラーが出ていた。
