### PR TITLE
fixed variable name typo that was preventing mail notifications

### DIFF
--- a/app/Controller/Component/MailerComponent.php
+++ b/app/Controller/Component/MailerComponent.php
@@ -4,7 +4,7 @@ App::uses('CakeEmail', 'Network/Email');
 class MailerComponent extends Component {
 
 	public function startup(Controller $controller) {
-		$this->Controller = $Controller;
+		$this->Controller = $controller;
 
 		if (extension_loaded('mbstring')) {
 			switch (Configure::read('Config.language')) {


### PR DESCRIPTION
seems like the variable name in the MailerComponent::startup() was accidentally changed at b65caa5.

This is my first pull request, and really not sure even if Im supposed to send a pull request for a single type...
So if it seems that Im doing anything weird or wrong I apologize, and I would really like to know what Im doing wrong :D

Best Regards.

miyahira
