### PR TITLE
Bug TimeLog Controller - Redirecting All requests to Login

### DIFF
--- a/app/Controller/TimelogController.php
+++ b/app/Controller/TimelogController.php
@@ -234,8 +234,10 @@ class TimelogController extends AppController
     } elseif(!empty($this->request->params['project_id'])) {
       ; // parent::beforeFilter
     }
-    parent::_findProject();
+    //_findProject uses the $this->current_user variable
     parent::user_setup();
+    parent::_findProject();
+    
     if(!$this->TimeEntry->User->is_allowed_to($this->current_user, 'view_time_entries', $this->_project, array('global' => true))) {
       return parent::deny_access();
     }


### PR DESCRIPTION
I'm starting use candycane to my freelamce works, and the TimeTrack feature is the most important :),

All my Projects are private, and TimeLog Controller redirect all requests to login page.
On Public Projects It does not.

This code fixed my candycane.
