### PR TITLE
Wikiの添付ファイルがNot Foundになることがあるバグを修正

### DIFF
--- a/app/Model/WikiPage.php
+++ b/app/Model/WikiPage.php
@@ -317,7 +317,11 @@ class WikiPage extends AppModel {
 #  end
 #end
 	function project() {
-		$wiki = $this->read('Wiki.*', $this->data['Wiki']['id']);
+		if (isset($this->data['Wiki'])) {
+			$wiki = $this->data;
+		} else {
+			$wiki = $this->read('Wiki.*', $this->data['WikiPage']['id']);
+		}
 		$project = $this->Wiki->find('first', array('conditions' => array('Project.id' =>  $wiki['Wiki']['project_id'])));
 
 		return $project;


### PR DESCRIPTION
WikiPage::project 関数内でWikiPage.idを使用して検索すべき所でWiki.idを使用してるっぽいのを修正しました。

あと、Wikiが存在してる場合の方が多そう(100%?)なので既にWikiがある場合はそっちを使うようにしています。
