### PR TITLE
fix #413

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -236,11 +236,7 @@ class AppController extends Controller {
 		if (!$this->current_user || !$this->current_user['logged']) {
 			$this->redirect(
 				'/account/login?back_url=' . 
-				urlencode(
-					'http://' . 
-					env('HTTP_HOST') . 
-					env('REQUEST_URI')
-				)
+				urlencode(Router::url(env('REQUEST_URI'), true))
 			);
 			#      redirect_to :controller => "account", :action => "login", :back_url => url_for(params)
 			return false;


### PR DESCRIPTION
back_urlのプロトコルがhttp固定なのをRouter::url使って直してみました:smile:

パッと見Redmineの方も使ってなかったので無視したんですが、CandyCaneの設定自体のプロトコル参照した方が良かったかな?
