### PR TITLE
fix #435

### DIFF
--- a/app/View/Elements/issues/list.ctp
+++ b/app/View/Elements/issues/list.ctp
@@ -5,7 +5,7 @@
 			$this->Html->image('toggle_check.png'),
 			array(),
 			array(
-				'onclick' => 'toggleIssuesSelection(Element.strtoupper(this, "form")); return false;',
+				'onclick' => "toggleIssuesSelection(Element.up(this, 'table')); return false;",
 				'title' => __('Check all') . '/' . __('Uncheck all'),
 				'escape' => false
 			)


### PR DESCRIPTION
チケット一覧で全チェックのtoggleが動いてないのを修正しました。CandyCaneのチケットに書かれてた方法よりChromeで2倍くらい早かったからチケットのと修正方法多少違います。
