### PR TITLE
Spyc の App::import 追加

### DIFF
--- a/app/Model/Query.php
+++ b/app/Model/Query.php
@@ -1,4 +1,7 @@
 <?php
+
+App::Import('vendor', 'georgious-cakephp-yaml-migrations-and-fixtures/spyc/spyc');
+
 class Query extends AppModel
 {
   var $name = 'Query';


### PR DESCRIPTION
app/Model/Query.php だけ Spyc を読み込んでなくて、QueriesComponent 単体でテストした時にコケてたので読み込むように修正しました。
