### PR TITLE
QueriesComponentTestがdefaultコネクションを見てしまってエラーになるのを修正

### DIFF
--- a/app/Model/Query.php
+++ b/app/Model/Query.php
@@ -29,7 +29,7 @@ class Query extends AppModel
   var $available_filters;
   var $filters = array();
   
-  function __construct()
+  public function __construct($id = false, $table = null, $ds = null)
   {
     if (!$this->operators) {
       $this->operators = array(
@@ -74,7 +74,7 @@ class Query extends AppModel
         ),
       );
     }
-    parent::__construct();
+    parent::__construct($id, $table, $ds);
   }
   
   function available_filters($project = array(), $currentuser = array())

--- a/app/Test/Case/Controller/Component/QueriesComponentTest.php
+++ b/app/Test/Case/Controller/Component/QueriesComponentTest.php
@@ -60,8 +60,8 @@ class QueriesComponentTest extends CakeTestCase
         $CakeRequest = new CakeRequest();
         $CakeResponse = new CakeResponse();
         $this->Controller = new QueriesComponentTestController($CakeRequest, $CakeResponse);
-        $this->Controller->Query = new Query();
-        $this->Controller->Project = new Project();
+        $this->Controller->Query = ClassRegistry::init('Query');
+        $this->Controller->Project = ClassRegistry::init('Project');
         $this->Component = new QueriesComponent($Collection);
         $this->Component->startup($this->Controller);
     }
@@ -129,7 +129,6 @@ class QueriesComponentTest extends CakeTestCase
         
         //get parameter for query_id = 1
         $this->assertEqual($this->Component->retrieve_query(1),null);
-        return;
         $this->assertEqual(
             $this->Controller->request->data,
             array(


### PR DESCRIPTION
ClassRegistry::init を使用するようにしたのと、Model/Query.php の __construct が親クラスと違ってたのを直しました。
