### PR TITLE
Could not open input file: vendor/bin/coveralls on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ before_script:
 script:
   - mkdir -p build/logs
   - cd ./app; ./Console/cake test app All --stderr --coverage-clover ../build/logs/clover.xml --configuration ../phpunit.xml.dist
+  - cd ../
 
 after_script:
   - php vendor/bin/coveralls


### PR DESCRIPTION
`vendor/bin/coveralls` was not found due to cd ./app before test (this means `app/vendor/bin/coveralls`).
So, I think `cd ../` command should be executed.
