### PR TITLE
説明に改行が入っているチケットが表示できないのを修正

### DIFF
--- a/app/View/Helper/WatchersHelper.php
+++ b/app/View/Helper/WatchersHelper.php
@@ -30,7 +30,7 @@ class WatchersHelper extends AppHelper
   }
 
   function watcher_link($object, $user) {
-    $watched_by = $this->requestAction(array('controller'=>'issues', 'action'=>'watched_by'), compact('object'));
+    $watched_by = $this->requestAction(array('controller'=>'issues', 'action'=>'watched_by'));
     if(!($user && $user['logged'])) {
       return '';
     }


### PR DESCRIPTION
とりあえずパラメータを消しても動くのでエラーの元になるパラメータ消しました。

ただ、呼び出す時の状況に依存しちゃってるので requestAction を使ってる所を綺麗にしたほうが良い気がします。
requestAction に Model の配列渡さずに ID 渡すとか普段使うような URL にしとかないとまたなにか起きる気がしますです。
