### PR TITLE
convert e function to echo function.

### DIFF
--- a/app/View/Wiki/history.ctp
+++ b/app/View/Wiki/history.ctp
@@ -42,14 +42,14 @@ if (isset($next_version[$first_version_value])) {
 <?php foreach ($versions as $ver) : /*@versions.each do |ver|*/ ?>
 <tr class="<?php echo $this->Candy->cycle("odd", "even"); ?>">
    <td class="id">
-   <?php e($this->Html->link($ver['WikiContentVersion']['version'],
+   <?php echo($this->Html->link($ver['WikiContentVersion']['version'],
                        array('action' => 'index',
                              'project_id' => $main_project['Project']['identifier'],
                              'wikipage'   => $page['WikiPage']['title'],
                              '?version='. $ver['WikiContentVersion']['version']))); ?></td>
 <td class="checkbox"><?php
    if ($show_diff && ($line_num < sizeof($versions))) {
-     e($this->Form->input('version',
+     echo($this->Form->input('version',
                     array('type'=>'radio',
                           'options' => array($ver['WikiContentVersion']['version'] => null),
                           'value' => $first_version_value,
@@ -61,7 +61,7 @@ if (isset($next_version[$first_version_value])) {
    } ?></td>
 <td class="checkbox"><?php
    if ($show_diff && ($line_num > 1)) {
-     e($this->Form->input('version_from',
+     echo($this->Form->input('version_from',
                     array('type'=>'radio',
                           'options' => array($ver['WikiContentVersion']['version'] => null),
                           'value' => $second_version_value,


### PR DESCRIPTION
history.ctpで利用しているe関数が、エラーとなっているようです。

[Sun Jun 02 14:16:42 2013] [error] [client 101.143.145.61] PHP Fatal error:  Call to undefined function e() in /var/www/candycane/app/View/Wiki/history.ctp on line 45, referer: http://friends-map.net/candycane/projects/friends-map/wiki/Wiki

echoに書き換えることで動作しました。
