### PR TITLE
<title> のフォーマットを変更

### DIFF
--- a/app/View/Helper/CandyHelper.php
+++ b/app/View/Helper/CandyHelper.php
@@ -90,44 +90,39 @@ class CandyHelper extends AppHelper {
 		call_user_func_array(array($this, 'lwr_e'), $argv);
 	}
 
-/**
- * Html Title
- *
- * @param array $str Strings to display
- * @return string
- */
-	public function html_title($str = false) {
-		$view = $this->_View;
-		$project = isset($view->viewVars['main_project']) ? $view->viewVars['main_project'] : null;
-		if (empty($str)) {
-			$title = array();
-			if (! empty($project)) {
-				$title[0] = $project['Project']['name'];
-			} else {
-				$Settings =& ClassRegistry::getObject('Setting');
-				$title[0] = $Settings->app_title;
-			}
-			if (!empty($view->pageTitle)) {
-				$title[0] .= $view->pageTitle;
-			}
-			$title = join(' - ', $title);
-			$str = $view->pageTitle = $title;
-		} elseif (is_string($str)) {
-			$title[] = $str;
-			if (! empty($project)) {
-				$title[] = $project['Project']['name'];
-			}
-			$Settings =& ClassRegistry::getObject('Setting');
-			$title[] = $Settings->app_title;
-			$title = join(' - ', $title);
-			$str = $view->pageTitle = $title;
-		} elseif(is_array($str)) {
-			$str = join(' - ', $str);
-		}
-		$view->set('title_for_layout',$str);
-		$view->pageTitle = $str;
-		return $view->pageTitle;
-	}
+    /**
+     * Html Title
+     *
+     * @param array $str Strings to display
+     * @return string
+     */
+    public function html_title($str = false) {
+        $view = $this->_View;
+        $project = isset($view->viewVars['main_project']) ? $view->viewVars['main_project'] : null;
+
+        if (is_array($str)) {
+            $view->pageTitle = implode(' - ', $str);
+        } else {
+            $view->pageTitle = $str;
+        }
+
+        if (!is_array($str)) {
+            $title = Hash::merge(array(), $str);
+
+            if (!empty($project)) {
+                $title[] = $project['Project']['name'];
+            }
+
+            $Settings =& ClassRegistry::getObject('Setting');
+            $title[] = $Settings->app_title;
+
+            $str = implode(' - ', $title);
+        }
+
+        $view->set('title_for_layout',$str);
+
+        return $view->pageTitle;
+    }
 
 #require 'coderay'
 #require 'coderay/helpers/file_type'


### PR DESCRIPTION
「チケット」とかだけあってもわけわからないので、「チケット - Project - CandyCane」みたいに「ページ名 (- プロジェクト名) - サイト名」になるようにしてみました。

ついでに不要そうな処理消したりして多少綺麗にしました:blush:
# 

で、ここからが相談なんですが、 CandyHelper::html_title に配列でタイトルって渡しますか?
特に今の所配列で渡してる所ないっぽいし、配列で渡すのが不要になればもうちょっとサッパリするんですが:weary:
