### PR TITLE
プロジェクト管理の表示件数制限をなくした (fix #445)

### DIFF
--- a/app/Controller/AdminController.php
+++ b/app/Controller/AdminController.php
@@ -67,7 +67,6 @@ class AdminController extends AppController
             array(
                 'recursive' => 0,
                 'conditions' => $condition,
-                'limit' => 10,
             )
         );
 


### PR DESCRIPTION
プロジェクト管理で10件しか表示されないのをとっぱらってみました。

件数がだいぶ多くなるようならもうちょっと考えたほうが良いかもですが、そんなに多くなるのかな?

あと、Redmineみたいな子プロジェクトを考慮した見た目とかにするのであれば、またそれっぽい感じにするのを考えないといけないかも。

親プロジェクト
└子プロジェクト
