### PR TITLE
ユーザ名の表示書式が大体反映されるようにした

### DIFF
--- a/app/Model/Project.php
+++ b/app/Model/Project.php
@@ -550,8 +550,11 @@ class Project extends AppModel {
     $fields = array('User.*');
     $users = $this->Member->find('all', compact('conditions', 'recursive', 'order', 'fields'));
     $list = array();
+    // @FIXME
+    App::uses('CandyHelper', 'View/Helper');
+    $candy = new CandyHelper(new View());
     foreach($users as $user) {
-      $list[$user['User']['id']] = $user['User']['firstname'].' '.$user['User']['lastname'];
+      $list[$user['User']['id']] = $candy->format_username($user['User']);
     }
     return $list;
   }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -147,17 +147,16 @@ class User extends AppModel {
 #  
   function name($user, $formatter = null)
   {
-    // @FIXME
+      // @FIXME
+      App::uses('CandyHelper', 'View/Helper');
+      $candy = new CandyHelper(new View());
 
-    if ($formatter != null) {
-    } else {
-    }
-    $alias = 'User';
-    if(array_key_exists($this->alias, $user)) {
-      $alias = $this->alias;
-    }
+      $alias = 'User';
+      if(array_key_exists($this->alias, $user)) {
+          $alias = $this->alias;
+      }
 
-    return $user[$alias]['firstname']. ' '.$user[$alias]['lastname'];
+      return $candy->format_username($user[$alias], $formatter);
   }
   function name_fields() {
     return array('firstname', 'lastname');

--- a/app/Test/Case/Model/UserTest.php
+++ b/app/Test/Case/Model/UserTest.php
@@ -12,7 +12,7 @@ class UserTestCase extends CakeTestCase {
  *
  * @var array
  */
-    public $fixtures = array('app.user', 'app.token', 'app.user_preference', 'app.member', 'app.project', 'app.wiki', 'app.wiki_page', 'app.wiki_content', 'app.wiki_content_version', 'app.wiki_redirect', 'app.issue_category', 'app.version', 'app.issue', 'app.issue_status', 'app.enumeration', 'app.tracker', 'app.workflow', 'app.time_entry', 'app.changeset', 'app.changesets_issue', 'app.enabled_module', 'app.projects_tracker', 'app.custom_field', 'app.custom_fields_project', 'app.role');
+    public $fixtures = array('app.user', 'app.token', 'app.user_preference', 'app.member', 'app.project', 'app.wiki', 'app.wiki_page', 'app.wiki_content', 'app.wiki_content_version', 'app.wiki_redirect', 'app.issue_category', 'app.version', 'app.issue', 'app.issue_status', 'app.enumeration', 'app.tracker', 'app.workflow', 'app.time_entry', 'app.changeset', 'app.changesets_issue', 'app.enabled_module', 'app.projects_tracker', 'app.custom_field', 'app.custom_fields_project', 'app.role', 'app.setting');
 
 /**
  * setUp method
@@ -61,10 +61,13 @@ class UserTestCase extends CakeTestCase {
  * @return void
  */
     public function testName() {
+        ClassRegistry::init('Setting');
+
         $data = array(
             'User' => array(
                 'firstname' => 'foo',
                 'lastname' => 'bar',
+                'login' => 'baz',
             ),
         );
 
@@ -72,9 +75,9 @@ class UserTestCase extends CakeTestCase {
         $this->assertEqual('foo bar', $results);
 
         // @TODO fix formatter
-        $formatter = 'formatter';
+        $formatter = 'lastname_coma_firstname';
         $results = $this->User->name($data, $formatter);
-        $this->assertEqual('foo bar', $results);
+        $this->assertEqual('bar, foo', $results);
     }
 /**
  * testNameFields method
@@ -185,10 +188,13 @@ class UserTestCase extends CakeTestCase {
  * @return void
  */
     public function testToString() {
+        ClassRegistry::init('Setting');
+
         $data = array(
             'User' => array(
                 'firstname' => 'foo',
                 'lastname' => 'bar',
+                'login' => 'baz',
             ),
         );
         $results = $this->User->to_string($data);

--- a/app/Test/Case/View/Helper/AppFormTest.php
+++ b/app/Test/Case/View/Helper/AppFormTest.php
@@ -20,7 +20,7 @@ class AppFormTest extends CakeTestCase {
       'app.enumeration', 'app.issue_category', 'app.token', 'app.member', 'app.role', 'app.user_preference',
       'app.enabled_module', 'app.issue_category', 'app.time_entry', 'app.changeset', 'app.changesets_issue', 'app.attachment',
       'app.projects_tracker', 'app.custom_value', 'app.custom_field', 'app.watcher','app.custom_fields_project',
-      'app.wiki', 'app.wiki_page', 'app.wiki_content', 'app.wiki_content_version', 'app.wiki_redirect','app.workflow'
+      'app.wiki', 'app.wiki_page', 'app.wiki_content', 'app.wiki_content_version', 'app.wiki_redirect','app.workflow', 'app.setting',
   );
 
   function setUp() {
@@ -289,7 +289,9 @@ class AppFormTest extends CakeTestCase {
   }
 
   function test_format_criteria_value_member() {
-    $this->loadFixtures('User','Token','UserPreference','Member');
+    $this->loadFixtures('User','Token','UserPreference','Member', 'Setting');
+    ClassRegistry::init('Setting');
+
     $locale = Configure::write('Config.language', 'en');
     $available_criterias = array(
       'member'   => array('sql' => "TimeEntry.user_id",

--- a/app/View/Helper/IssuesHelper.php
+++ b/app/View/Helper/IssuesHelper.php
@@ -61,83 +61,85 @@ class IssuesHelper extends AppHelper
 #    @sidebar_queries
 #  end
 #
-  public function show_detail($detail, $no_html=false) {
-    $result = $this->requestAction(array('controller'=>'issues', 'action'=>'detail_values'), compact('detail'));
-    // $label, $value, $old_value, $field_format, $attachment
-    extract($result);
-    switch($detail['property']) {
-    case 'attr' :
-      $label = __($detail['prop_key']);
-      switch($detail['prop_key']) {
-      case 'due_date' :
-      case 'start_date' :
-        if(!empty($detail['value'])) $value = $this->Candy->format_date($detail['value']);
-        if(!empty($detail['old_value'])) $old_value = $this->Candy->format_date($detail['old_value']);
-        break;
-      case 'estimated_hours' :
-        if($detail['value'] != '') $value = ($detail['value'] ==0 ? 0 : "%0.02f" % $detail['value']);
-        if($detail['old_value'] != '') $old_value = ($detail['old_value'] == 0 ? 0 : "%0.02f" % $detail['old_value']);
-        break;
-      }
-      break;
-    case 'cf' :
-      if(!empty($field_format)) {
-        $value = $this->CustomField->format_value($detail['value'], $field_format);
-        $old_value = $this->CustomField->format_value($detail['old_value'], $field_format);
-      }
-      break;
-    case 'attachment' :
-      $label = __('File');
-      break;
-    }
-    // TODO : For plugin, call_hook 
-    // call_hook(:helper_issues_show_detail_after_setting, {:detail => detail, :label => label, :value => value, :old_value => old_value })
-
-    if(empty($label)) $label = $detail['prop_key'];
-    if(empty($value)) $value = $detail['value'];
-    if(empty($old_value)) $old_value = $detail['old_value'];
-    
-    if(!empty($label)) $label = $this->Candy->label_text($label);
-    if(!$no_html) {
-      $label = $this->Html->tag('strong', $label);
-      if(!empty($detail['old_value'])) $old_value = $this->Html->tag("i", h($old_value));
-      if(!empty($detail['old_value']) && (!$detail['value'] || empty($detail['value']))) $old_value = $this->Html->tag("strike", $old_value); 
-      if($detail['property'] == 'attachment' && ($value != '') && !empty($attachment)) {
-        # Link to the attachment if it has not been removed
-        $value = $this->Candy->link_to_attachment($attachment);
-      } else {
-        if(!empty($value)) $value = $this->Html->tag("i", h($value));
-      }
-    }
-    
-    $out = '';
-    if($detail['value'] != '') {
-      switch($detail['property']) {
-      case 'attr' :
-      case 'cf' :
-        if($detail['old_value'] != '') {
-          $out = $label." ".sprintf(__('changed from %s to %s'), $old_value, $value);
-        } else {
-          $out = $label." ".sprintf(__('set to %s'), $value);
+    public function show_detail($detail, $no_html = false)
+    {
+        $result = $this->requestAction(array('controller'=>'issues', 'action'=>'detail_values'), compact('detail'));
+        // $label, $value, $old_value, $field_format, $attachment
+        extract($result);
+        switch($detail['property']) {
+            case 'attr' :
+                $label = __($detail['prop_key']);
+                switch($detail['prop_key']) {
+                    case 'due_date' :
+                    case 'start_date' :
+                        if(!empty($detail['value'])) $value = $this->Candy->format_date($detail['value']);
+                        if(!empty($detail['old_value'])) $old_value = $this->Candy->format_date($detail['old_value']);
+                        break;
+                    case 'estimated_hours' :
+                        if($detail['value'] != '') $value = ($detail['value'] ==0 ? 0 : "%0.02f" % $detail['value']);
+                        if($detail['old_value'] != '') $old_value = ($detail['old_value'] == 0 ? 0 : "%0.02f" % $detail['old_value']);
+                        break;
+                }
+                break;
+            case 'cf' :
+                if(!empty($field_format)) {
+                    $value = $this->CustomField->format_value($detail['value'], $field_format);
+                    $old_value = $this->CustomField->format_value($detail['old_value'], $field_format);
+                }
+                break;
+            case 'attachment' :
+                $label = __('File');
+                break;
         }
-        break;
-      case 'attachment' :
-        $out = "$label $value ".__('added');
-        break;
-      }
-    } else {
-      switch($detail['property']) {
-      case 'attr' :
-      case 'cf' :
-        $out = $label." ".__('deleted')." ($old_value)";
-        break;
-      case 'attachment' :
-        $out = "$label $old_value ".__('deleted');
-        break;
-      }
+        // TODO : For plugin, call_hook
+        // call_hook(:helper_issues_show_detail_after_setting, {:detail => detail, :label => label, :value => value, :old_value => old_value })
+
+        if(empty($label)) $label = $detail['prop_key'];
+        if(empty($value)) $value = $detail['value'];
+        if(empty($old_value)) $old_value = $detail['old_value'];
+
+        if(!empty($label)) $label = $this->Candy->label_text($label);
+        if(!$no_html) {
+            $label = $this->Html->tag('strong', $label);
+            if(!empty($detail['old_value'])) $old_value = $this->Html->tag("i", h($old_value));
+            if(!empty($detail['old_value']) && (!$detail['value'] || empty($detail['value']))) $old_value = $this->Html->tag("strike", $old_value); 
+            if($detail['property'] == 'attachment' && ($value != '') && !empty($attachment)) {
+                # Link to the attachment if it has not been removed
+                $value = $this->Candy->link_to_attachment($attachment);
+            } else {
+                if(!empty($value)) $value = $this->Html->tag("i", h($value));
+            }
+        }
+
+        $out = '';
+        if($detail['value'] != '') {
+            switch($detail['property']) {
+                case 'attr' :
+                case 'cf' :
+                    if($detail['old_value'] != '') {
+                        $out = $label." ".sprintf(__('changed from %s to %s'), $old_value, $value);
+                    } else {
+                        $out = $label." ".sprintf(__('set to %s'), $value);
+                    }
+                    break;
+                case 'attachment' :
+                    $out = "$label $value ".__('added');
+                    break;
+            }
+        } else {
+            switch($detail['property']) {
+                case 'attr' :
+                case 'cf' :
+                    $out = $label." ".__('deleted')." ($old_value)";
+                    break;
+                case 'attachment' :
+                    $out = "$label $old_value ".__('deleted');
+                    break;
+            }
+        }
+        return $out;
     }
-    return $out;
-  }
+
   function relation_issue($issue, $relation) {
     return ($relation['IssueRelation']['issue_from_id'] == $issue['Issue']['id']) ? $relation['IssueFrom'] : $relation['IssueTo'];
   }


### PR DESCRIPTION
チケット編集時の担当者とか、チケット編集履歴の担当者とかのユーザ名の形式が設定無視されてたのを修正しました。

ただ、format_usernameがCandyHelperになるのでちょっと気持ち悪いコードになっちゃった気がします……
