### PR TITLE
設定 > チケットトラッキングの一部が日本語化されてなかったのを直した

### DIFF
--- a/app/Locale/jpn/LC_MESSAGES/default.po
+++ b/app/Locale/jpn/LC_MESSAGES/default.po
@@ -936,6 +936,10 @@ msgstr "開始日"
 msgid "Start date"
 msgstr "開始日"
 
+# field_start_date 3
+msgid "start_date"
+msgstr "開始日"
+
 # field_password_confirmation
 msgid "Confirmation"
 msgstr "確認"


### PR DESCRIPTION
言語ファイル start_date と Start date みたいに2種類あったりするので片方に統一する方向でもっていった方が良いのかな?
