### PR TITLE
Ajaxで切り替えた後のformに [Issue] が付いてなくてエラーになっていたのを修正

### DIFF
--- a/app/View/Issues/update_form.ctp
+++ b/app/View/Issues/update_form.ctp
@@ -1,3 +1,4 @@
+<?php $this->Form->setEntity('Issue', true) ?>
 <?php echo $this->element('issues/attribute', array(
     'statuses', 'priorities', 'assignable_users', 'issue_categories',
     'fixed_versions', 'custom_field_values',


### PR DESCRIPTION
すいませんすいませんこないだのバグってました:persevere:

data[Issue][status_id] みたいになるのが正しいんですが、 data[status_id] になってたのを直しました。
