### PR TITLE
back_urlをCakeRequest::here()を使って生成する様に変更

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -242,7 +242,7 @@ class AppController extends Controller
         if (!$this->current_user || !$this->current_user['logged']) {
             $this->redirect(
                 '/account/login?back_url=' .
-                    urlencode(Router::url(env('REQUEST_URI'), true))
+                    urlencode(Router::url($this->request->here(false), true))
             );
             #      redirect_to :controller => "account", :action => "login", :back_url => url_for(params)
             return false;


### PR DESCRIPTION
http://example.com/foo/ の様にフォルダ有りの場所にCandyCaneを設置し、「認証が必要」にチェックを入れて、どこにアクセスするにもログインが必要な状態での動きです。
http://example.com/foo/ にアクセスすると、ログインページでback_urlがhttp://example.com/foo/になるはずのところ、 http://example.com/foo/foo/になるのを変更しました。
