### PR TITLE
チケット一覧のページャーのリンクがおかしくなるバグの修正。

### DIFF
--- a/app/View/Helper/CandyHelper.php
+++ b/app/View/Helper/CandyHelper.php
@@ -665,6 +665,7 @@ class CandyHelper extends AppHelper {
         unset($get_param[$paginator_param]);
       }
     }
+	unset($url_param[0]);
     $url_param['?'] = !empty($url_param['?']) ? am($url_param['?'], $get_param) : $get_param;
     $html = '';
     if ($paging['prevPage']) {


### PR DESCRIPTION
バグを確認したのはチケット一覧でステータスの絞り込みを行った後です。

一度目は問題なくページ移動出来るんですがそのタイミングでページャーのリンクがおかしくなりページ移動が出来なくなります。

修正後確認事項
ページャーの動作確認
View/Helper/CandyHelper.phpのテストが問題なく通る事

以上です。
宜しければマージの方宜しくお願い致します。
