### PR TITLE
Vagrantfile: updated shared folders option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,5 +7,5 @@ Vagrant.configure("2") do |config|
   src_dir = './'
   doc_root = '/vagrant_data/app/webroot'
   config.vm.network :forwarded_port, guest: 80, host: 8080
-  config.vm.synced_folder src_dir, "/vagrant_data", :create => true, :owner=> 'vagrant', :group=>'www-data', :extra => 'dmode=775,fmode=775'
+  config.vm.synced_folder src_dir, "/vagrant_data", :create => true, :owner=> 'vagrant', :group=>'www-data', :mount_options => ['dmode=775', 'fmode=775']
 end


### PR DESCRIPTION
shared folders option has been replaced from `:extra` to `:mount_options`.

https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md#130-september-5-2013
