### PR TITLE
Add code to use table prefix for mysql

### DIFF
--- a/app/Config/sql/mysql.sql.install
+++ b/app/Config/sql/mysql.sql.install
@@ -1,0 +1,1297 @@
+-- phpMyAdmin SQL Dump
+-- version 3.1.1
+-- http://www.phpmyadmin.net
+--
+-- ホスト: localhost
+-- 生成時間: 2009 年 3 月 21 日 21:27
+-- サーバのバージョン: 5.1.30
+-- PHP のバージョン: 5.2.8
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+
+--
+-- データベース: `redmine_development`
+--
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `attachments`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}attachments` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `container_id` int(11) NOT NULL DEFAULT '0',
+  `container_type` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `filename` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `disk_filename` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `filesize` int(11) NOT NULL DEFAULT '0',
+  `content_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `digest` varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `downloads` int(11) NOT NULL DEFAULT '0',
+  `author_id` int(11) NOT NULL DEFAULT '0',
+  `created_on` datetime DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `attachments`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `auth_sources`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}auth_sources` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `type` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(60) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `host` varchar(60) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `port` int(11) DEFAULT NULL,
+  `account` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `account_password` varchar(60) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `base_dn` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `attr_login` varchar(30) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `attr_firstname` varchar(30) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `attr_lastname` varchar(30) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `attr_mail` varchar(30) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `onthefly_register` tinyint(1) NOT NULL DEFAULT '0',
+  `tls` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `auth_sources`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `boards`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}boards` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `position` int(11) DEFAULT '1',
+  `topics_count` int(11) NOT NULL DEFAULT '0',
+  `messages_count` int(11) NOT NULL DEFAULT '0',
+  `last_message_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `boards_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `boards`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `changes`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}changes` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `changeset_id` int(11) NOT NULL,
+  `action` varchar(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `path` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `from_path` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `from_revision` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `revision` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `branch` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `changesets_changeset_id` (`changeset_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `changes`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `changesets`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}changesets` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `repository_id` int(11) NOT NULL,
+  `revision` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `committer` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `committed_on` datetime NOT NULL,
+  `comments` text COLLATE utf8_unicode_ci,
+  `commit_date` date DEFAULT NULL,
+  `scmid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `changesets_repos_rev` (`repository_id`,`revision`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `changesets`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `changesets_issues`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}changesets_issues` (
+  `changeset_id` int(11) NOT NULL,
+  `issue_id` int(11) NOT NULL,
+  UNIQUE KEY `changesets_issues_ids` (`changeset_id`,`issue_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- テーブルのデータをダンプしています `changesets_issues`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `comments`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}comments` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `commented_type` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `commented_id` int(11) NOT NULL DEFAULT '0',
+  `author_id` int(11) NOT NULL DEFAULT '0',
+  `comments` text COLLATE utf8_unicode_ci,
+  `created_on` datetime NOT NULL,
+  `updated_on` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `comments`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `custom_fields`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}custom_fields` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `type` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `field_format` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `possible_values` text COLLATE utf8_unicode_ci,
+  `regexp` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `min_length` int(11) NOT NULL DEFAULT '0',
+  `max_length` int(11) NOT NULL DEFAULT '0',
+  `is_required` tinyint(1) NOT NULL DEFAULT '0',
+  `is_for_all` tinyint(1) NOT NULL DEFAULT '0',
+  `is_filter` tinyint(1) NOT NULL DEFAULT '0',
+  `position` int(11) DEFAULT '1',
+  `searchable` tinyint(1) DEFAULT '0',
+  `default_value` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `custom_fields`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `custom_fields_projects`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}custom_fields_projects` (
+  `custom_field_id` int(11) NOT NULL DEFAULT '0',
+  `project_id` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- テーブルのデータをダンプしています `custom_fields_projects`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `custom_fields_trackers`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}custom_fields_trackers` (
+  `custom_field_id` int(11) NOT NULL DEFAULT '0',
+  `tracker_id` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- テーブルのデータをダンプしています `custom_fields_trackers`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `custom_values`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}custom_values` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `customized_type` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `customized_id` int(11) NOT NULL DEFAULT '0',
+  `custom_field_id` int(11) NOT NULL DEFAULT '0',
+  `value` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`),
+  KEY `custom_values_customized` (`customized_type`,`customized_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `custom_values`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `documents`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}documents` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `category_id` int(11) NOT NULL DEFAULT '0',
+  `title` varchar(60) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `description` text COLLATE utf8_unicode_ci,
+  `created_on` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `documents_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `documents`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `enabled_modules`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}enabled_modules` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `enabled_modules_project_id` (`project_id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=9 ;
+
+--
+-- テーブルのデータをダンプしています `enabled_modules`
+--
+
+INSERT INTO `{prefix}enabled_modules` (`id`, `project_id`, `name`) VALUES
+(1, 1, 'issue_tracking'),
+(2, 1, 'time_tracking'),
+(3, 1, 'news'),
+(4, 1, 'documents'),
+(5, 1, 'files'),
+(6, 1, 'wiki'),
+(7, 1, 'repository'),
+(8, 1, 'boards');
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `enumerations`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}enumerations` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `opt` varchar(4) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `position` int(11) DEFAULT '1',
+  `is_default` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=10 ;
+
+--
+-- テーブルのデータをダンプしています `enumerations`
+--
+
+INSERT INTO `{prefix}enumerations` (`id`, `opt`, `name`, `position`, `is_default`) VALUES
+(1, 'DCAT', 'User documentation', 1, 0),
+(2, 'DCAT', 'Technical documentation', 2, 0),
+(3, 'IPRI', 'Low', 1, 0),
+(4, 'IPRI', 'Normal', 2, 1),
+(5, 'IPRI', 'High', 3, 0),
+(6, 'IPRI', 'Urgent', 4, 0),
+(7, 'IPRI', 'Immediate', 5, 0),
+(8, 'ACTI', 'Design', 1, 0),
+(9, 'ACTI', 'Development', 2, 0);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `issues`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}issues` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `tracker_id` int(11) NOT NULL DEFAULT '0',
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `subject` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `description` text COLLATE utf8_unicode_ci,
+  `due_date` date DEFAULT NULL,
+  `category_id` int(11) DEFAULT NULL,
+  `status_id` int(11) NOT NULL DEFAULT '0',
+  `assigned_to_id` int(11) DEFAULT NULL,
+  `priority_id` int(11) NOT NULL DEFAULT '0',
+  `fixed_version_id` int(11) DEFAULT NULL,
+  `author_id` int(11) NOT NULL DEFAULT '0',
+  `lock_version` int(11) NOT NULL DEFAULT '0',
+  `created_on` datetime DEFAULT NULL,
+  `updated_on` datetime DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `done_ratio` int(11) NOT NULL DEFAULT '0',
+  `estimated_hours` float DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `issues_project_id` (`project_id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=2 ;
+
+--
+-- テーブルのデータをダンプしています `issues`
+--
+
+INSERT INTO `{prefix}issues` (`id`, `tracker_id`, `project_id`, `subject`, `description`, `due_date`, `category_id`, `status_id`, `assigned_to_id`, `priority_id`, `fixed_version_id`, `author_id`, `lock_version`, `created_on`, `updated_on`, `start_date`, `done_ratio`, `estimated_hours`) VALUES
+(1, 1, 1, 'Sample Ticket', 'Hello candycane users.', NULL, NULL, 1, NULL, 4, NULL, 3, 0, '2009-03-14 10:32:00', '2009-03-14 10:32:00', '2009-03-14', 0, NULL);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `issue_categories`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}issue_categories` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `assigned_to_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `issue_categories_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `issue_categories`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `issue_relations`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}issue_relations` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `issue_from_id` int(11) NOT NULL,
+  `issue_to_id` int(11) NOT NULL,
+  `relation_type` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `delay` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `issue_relations`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `issue_statuses`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}issue_statuses` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `is_closed` tinyint(1) NOT NULL DEFAULT '0',
+  `is_default` tinyint(1) NOT NULL DEFAULT '0',
+  `position` int(11) DEFAULT '1',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=7 ;
+
+--
+-- テーブルのデータをダンプしています `issue_statuses`
+--
+
+INSERT INTO `{prefix}issue_statuses` (`id`, `name`, `is_closed`, `is_default`, `position`) VALUES
+(1, 'New', 0, 1, 1),
+(2, 'Assigned', 0, 0, 2),
+(3, 'Resolved', 0, 0, 3),
+(4, 'Feedback', 0, 0, 4),
+(5, 'Closed', 1, 0, 5),
+(6, 'Rejected', 1, 0, 6);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `journals`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}journals` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `journalized_id` int(11) NOT NULL DEFAULT '0',
+  `journalized_type` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `user_id` int(11) NOT NULL DEFAULT '0',
+  `notes` text COLLATE utf8_unicode_ci,
+  `created_on` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `journals_journalized_id` (`journalized_id`,`journalized_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `journals`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `journal_details`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}journal_details` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `journal_id` int(11) NOT NULL DEFAULT '0',
+  `property` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `prop_key` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `old_value` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `journal_details_journal_id` (`journal_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `journal_details`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `members`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}members` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL DEFAULT '0',
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `role_id` int(11) NOT NULL DEFAULT '0',
+  `created_on` datetime DEFAULT NULL,
+  `mail_notification` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `members`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `messages`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}messages` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `board_id` int(11) NOT NULL,
+  `parent_id` int(11) DEFAULT NULL,
+  `subject` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `content` text COLLATE utf8_unicode_ci,
+  `author_id` int(11) DEFAULT NULL,
+  `replies_count` int(11) NOT NULL DEFAULT '0',
+  `last_reply_id` int(11) DEFAULT NULL,
+  `created_on` datetime NOT NULL,
+  `updated_on` datetime NOT NULL,
+  `locked` tinyint(1) DEFAULT '0',
+  `sticky` int(11) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `messages_board_id` (`board_id`),
+  KEY `messages_parent_id` (`parent_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `messages`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `news`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}news` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) DEFAULT NULL,
+  `title` varchar(60) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `summary` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `description` text COLLATE utf8_unicode_ci,
+  `author_id` int(11) NOT NULL DEFAULT '0',
+  `created_on` datetime DEFAULT NULL,
+  `comments_count` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `news_project_id` (`project_id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=2 ;
+
+--
+-- テーブルのデータをダンプしています `news`
+--
+
+INSERT INTO `{prefix}news` (`id`, `project_id`, `title`, `summary`, `description`, `author_id`, `created_on`, `comments_count`) VALUES
+(1, 1, 'Sample News', 'Working fine.', 'Worked\r\n*YEAH!!*', 3, '2009-03-20 23:25:45', 0);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `plugin_schema_info`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}plugin_schema_info` (
+  `plugin_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `version` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- テーブルのデータをダンプしています `plugin_schema_info`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `projects`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}projects` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `description` text COLLATE utf8_unicode_ci,
+  `homepage` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `is_public` tinyint(1) NOT NULL DEFAULT '1',
+  `parent_id` int(11) DEFAULT NULL,
+  `projects_count` int(11) DEFAULT '0',
+  `created_on` datetime DEFAULT NULL,
+  `updated_on` datetime DEFAULT NULL,
+  `identifier` varchar(20) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `status` int(11) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=2 ;
+
+--
+-- テーブルのデータをダンプしています `projects`
+--
+
+INSERT INTO `{prefix}projects` (`id`, `name`, `description`, `homepage`, `is_public`, `parent_id`, `projects_count`, `created_on`, `updated_on`, `identifier`, `status`) VALUES
+(1, 'Sample Project', 'Candycane rocks!', '', 1, NULL, 0, '2009-03-04 23:09:49', '2009-03-04 23:09:49', 'sampleproject', 1);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `projects_trackers`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}projects_trackers` (
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `tracker_id` int(11) NOT NULL DEFAULT '0',
+  KEY `projects_trackers_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- テーブルのデータをダンプしています `projects_trackers`
+--
+
+INSERT INTO `{prefix}projects_trackers` (`project_id`, `tracker_id`) VALUES
+(1, 1),
+(1, 2),
+(1, 3);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `queries`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}queries` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `filters` text COLLATE utf8_unicode_ci,
+  `user_id` int(11) NOT NULL DEFAULT '0',
+  `is_public` tinyint(1) NOT NULL DEFAULT '0',
+  `column_names` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `queries`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `repositories`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}repositories` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `url` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `login` varchar(60) COLLATE utf8_unicode_ci DEFAULT '',
+  `password` varchar(60) COLLATE utf8_unicode_ci DEFAULT '',
+  `root_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `repositories`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `roles`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}roles` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `position` int(11) DEFAULT '1',
+  `assignable` tinyint(1) DEFAULT '1',
+  `builtin` int(11) NOT NULL DEFAULT '0',
+  `permissions` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=6 ;
+
+--
+-- テーブルのデータをダンプしています `roles`
+--
+
+INSERT INTO `{prefix}roles` (`id`, `name`, `position`, `assignable`, `builtin`, `permissions`) VALUES
+(1, 'Non member', 1, 1, 1, '--- \n- :add_issues\n- :add_issue_notes\n- :save_queries\n- :view_gantt\n- :view_calendar\n- :view_time_entries\n- :comment_news\n- :view_documents\n- :view_wiki_pages\n- :view_wiki_edits\n- :add_messages\n- :view_files\n- :browse_repository\n- :view_changesets\n'),
+(2, 'Anonymous', 2, 1, 2, '--- \n- :view_gantt\n- :view_calendar\n- :view_time_entries\n- :view_documents\n- :view_wiki_pages\n- :view_wiki_edits\n- :view_files\n- :browse_repository\n- :view_changesets\n'),
+(3, 'Manager', 3, 1, 0, '--- \n- :edit_project\n- :select_project_modules\n- :manage_members\n- :manage_versions\n- :manage_categories\n- :add_issues\n- :edit_issues\n- :manage_issue_relations\n- :add_issue_notes\n- :edit_issue_notes\n- :edit_own_issue_notes\n- :move_issues\n- :delete_issues\n- :manage_public_queries\n- :save_queries\n- :view_gantt\n- :view_calendar\n- :view_issue_watchers\n- :add_issue_watchers\n- :log_time\n- :view_time_entries\n- :edit_time_entries\n- :edit_own_time_entries\n- :manage_news\n- :comment_news\n- :manage_documents\n- :view_documents\n- :manage_files\n- :view_files\n- :manage_wiki\n- :rename_wiki_pages\n- :delete_wiki_pages\n- :view_wiki_pages\n- :view_wiki_edits\n- :edit_wiki_pages\n- :delete_wiki_pages_attachments\n- :protect_wiki_pages\n- :manage_repository\n- :browse_repository\n- :view_changesets\n- :commit_access\n- :manage_boards\n- :add_messages\n- :edit_messages\n- :edit_own_messages\n- :delete_messages\n- :delete_own_messages\n'),
+(4, 'Developer', 4, 1, 0, '--- \n- :manage_versions\n- :manage_categories\n- :add_issues\n- :edit_issues\n- :manage_issue_relations\n- :add_issue_notes\n- :save_queries\n- :view_gantt\n- :view_calendar\n- :log_time\n- :view_time_entries\n- :comment_news\n- :view_documents\n- :view_wiki_pages\n- :view_wiki_edits\n- :edit_wiki_pages\n- :delete_wiki_pages\n- :add_messages\n- :edit_own_messages\n- :view_files\n- :manage_files\n- :browse_repository\n- :view_changesets\n- :commit_access\n'),
+(5, 'Reporter', 5, 1, 0, '--- \n- :add_issues\n- :add_issue_notes\n- :save_queries\n- :view_gantt\n- :view_calendar\n- :log_time\n- :view_time_entries\n- :comment_news\n- :view_documents\n- :view_wiki_pages\n- :view_wiki_edits\n- :add_messages\n- :edit_own_messages\n- :view_files\n- :browse_repository\n- :view_changesets\n');
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `schema_migrations`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}schema_migrations` (
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  UNIQUE KEY `unique_schema_migrations` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- テーブルのデータをダンプしています `schema_migrations`
+--
+
+INSERT INTO `{prefix}schema_migrations` (`version`) VALUES
+('1'),
+('10'),
+('100'),
+('101'),
+('11'),
+('12'),
+('13'),
+('14'),
+('15'),
+('16'),
+('17'),
+('18'),
+('19'),
+('2'),
+('20'),
+('21'),
+('22'),
+('23'),
+('24'),
+('25'),
+('26'),
+('27'),
+('28'),
+('29'),
+('3'),
+('30'),
+('31'),
+('32'),
+('33'),
+('34'),
+('35'),
+('36'),
+('37'),
+('38'),
+('39'),
+('4'),
+('40'),
+('41'),
+('42'),
+('43'),
+('44'),
+('45'),
+('46'),
+('47'),
+('48'),
+('49'),
+('5'),
+('50'),
+('51'),
+('52'),
+('53'),
+('54'),
+('55'),
+('56'),
+('57'),
+('58'),
+('59'),
+('6'),
+('60'),
+('61'),
+('62'),
+('63'),
+('64'),
+('65'),
+('66'),
+('67'),
+('68'),
+('69'),
+('7'),
+('70'),
+('71'),
+('72'),
+('73'),
+('74'),
+('75'),
+('76'),
+('77'),
+('78'),
+('79'),
+('8'),
+('80'),
+('81'),
+('82'),
+('83'),
+('84'),
+('85'),
+('86'),
+('87'),
+('88'),
+('89'),
+('9'),
+('90'),
+('91'),
+('92'),
+('93'),
+('94'),
+('95'),
+('96'),
+('97'),
+('98'),
+('99');
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `settings`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}settings` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `value` text COLLATE utf8_unicode_ci,
+  `updated_on` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `settings`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `time_entries`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}time_entries` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `issue_id` int(11) DEFAULT NULL,
+  `hours` float NOT NULL,
+  `comments` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `activity_id` int(11) NOT NULL,
+  `spent_on` date NOT NULL,
+  `tyear` int(11) NOT NULL,
+  `tmonth` int(11) NOT NULL,
+  `tweek` int(11) NOT NULL,
+  `created_on` datetime NOT NULL,
+  `updated_on` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `time_entries_project_id` (`project_id`),
+  KEY `time_entries_issue_id` (`issue_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `time_entries`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `tokens`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}tokens` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL DEFAULT '0',
+  `action` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `value` varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `created_on` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=5 ;
+
+--
+-- テーブルのデータをダンプしています `tokens`
+--
+
+INSERT INTO `{prefix}tokens` (`id`, `user_id`, `action`, `value`, `created_on`) VALUES
+(1, 1, 'feeds', 'D7ukdhHJXK7MTwDELqToVcTHPczo4rbCsLTim0pv', '2009-03-04 23:03:11'),
+(2, 1, 'feeds', 'rV5I24UQkA7AImh0FOYM84eNSpDbsOpTFCRcMort', '2009-03-04 23:03:11'),
+(3, 3, 'feeds', 'Zi1s5C1vyA8TAzMXm2hAAIOD8CveWiT3LSI763Ie', '2009-03-04 23:08:46'),
+(4, 3, 'feeds', 'HxAUNOsdgv1y3m8Y0ilEOpW6P3sQaydgCxcmsHx8', '2009-03-04 23:08:46');
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `trackers`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}trackers` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `is_in_chlog` tinyint(1) NOT NULL DEFAULT '0',
+  `position` int(11) DEFAULT '1',
+  `is_in_roadmap` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=4 ;
+
+--
+-- テーブルのデータをダンプしています `trackers`
+--
+
+INSERT INTO `{prefix}trackers` (`id`, `name`, `is_in_chlog`, `position`, `is_in_roadmap`) VALUES
+(1, 'Bug', 1, 1, 0),
+(2, 'Feature', 1, 2, 1),
+(3, 'Support', 0, 3, 0);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `users`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `login` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `hashed_password` varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `firstname` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `lastname` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `mail` varchar(60) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `mail_notification` tinyint(1) NOT NULL DEFAULT '1',
+  `admin` tinyint(1) NOT NULL DEFAULT '0',
+  `status` int(11) NOT NULL DEFAULT '1',
+  `last_login_on` datetime DEFAULT NULL,
+  `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT '',
+  `auth_source_id` int(11) DEFAULT NULL,
+  `created_on` datetime DEFAULT NULL,
+  `updated_on` datetime DEFAULT NULL,
+  `type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=4 ;
+
+--
+-- テーブルのデータをダンプしています `users`
+--
+
+INSERT INTO `{prefix}users` (`id`, `login`, `hashed_password`, `firstname`, `lastname`, `mail`, `mail_notification`, `admin`, `status`, `last_login_on`, `language`, `auth_source_id`, `created_on`, `updated_on`, `type`) VALUES
+(1, 'admin', 'd033e22ae348aeb5660fc2140aec35850c4da997', 'Redmine', 'Admin', 'admin@example.net', 1, 1, 1, '2009-03-04 23:06:50', 'eng', NULL, '2009-03-04 23:00:57', '2009-03-04 23:06:50', 'User'),
+(2, '', '', '', 'Anonymous', '', 0, 0, 0, NULL, '', NULL, '2009-03-04 23:02:30', '2009-03-04 23:02:30', 'AnonymousUser'),
+(3, 'testuser', 'AWESOME', 'yusuke', 'ando', 'test@example.com', 0, 1, 1, '2009-03-20 23:24:42', 'jpn', NULL, '2009-03-04 23:06:32', '2009-03-20 23:24:42', NULL);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `user_preferences`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}user_preferences` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL DEFAULT '0',
+  `others` text COLLATE utf8_unicode_ci,
+  `hide_mail` tinyint(1) DEFAULT '0',
+  `time_zone` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=4 ;
+
+--
+-- テーブルのデータをダンプしています `user_preferences`
+--
+
+INSERT INTO `{prefix}user_preferences` (`id`, `user_id`, `others`, `hide_mail`, `time_zone`) VALUES
+(1, 1, '--- {}\n\n', 0, NULL),
+(2, 2, '--- {}\n\n', 0, NULL),
+(3, 3, '--- {}\n\n', 0, NULL);
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `versions`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}versions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL DEFAULT '0',
+  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `description` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `effective_date` date DEFAULT NULL,
+  `created_on` datetime DEFAULT NULL,
+  `updated_on` datetime DEFAULT NULL,
+  `wiki_page_title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `versions_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `versions`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `watchers`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}watchers` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `watchable_type` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `watchable_id` int(11) NOT NULL DEFAULT '0',
+  `user_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `watchers`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `wikis`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}wikis` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) NOT NULL,
+  `start_page` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `status` int(11) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`),
+  KEY `wikis_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `wikis`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `wiki_contents`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}wiki_contents` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `page_id` int(11) NOT NULL,
+  `author_id` int(11) DEFAULT NULL,
+  `text` text COLLATE utf8_unicode_ci,
+  `comments` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `updated_on` datetime NOT NULL,
+  `version` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `wiki_contents_page_id` (`page_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `wiki_contents`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `wiki_content_versions`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}wiki_content_versions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `wiki_content_id` int(11) NOT NULL,
+  `page_id` int(11) NOT NULL,
+  `author_id` int(11) DEFAULT NULL,
+  `data` blob,
+  `compression` varchar(6) COLLATE utf8_unicode_ci DEFAULT '',
+  `comments` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
+  `updated_on` datetime NOT NULL,
+  `version` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `wiki_content_versions_wcid` (`wiki_content_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `wiki_content_versions`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `wiki_pages`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}wiki_pages` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `wiki_id` int(11) NOT NULL,
+  `title` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `created_on` datetime NOT NULL,
+  `protected` tinyint(1) NOT NULL DEFAULT '0',
+  `parent_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `wiki_pages_wiki_id_title` (`wiki_id`,`title`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `wiki_pages`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `wiki_redirects`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}wiki_redirects` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `wiki_id` int(11) NOT NULL,
+  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `redirects_to` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_on` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `wiki_redirects_wiki_id_title` (`wiki_id`,`title`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
+
+--
+-- テーブルのデータをダンプしています `wiki_redirects`
+--
+
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `workflows`
+--
+
+CREATE TABLE IF NOT EXISTS `{prefix}workflows` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `tracker_id` int(11) NOT NULL DEFAULT '0',
+  `old_status_id` int(11) NOT NULL DEFAULT '0',
+  `new_status_id` int(11) NOT NULL DEFAULT '0',
+  `role_id` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `wkfs_role_tracker_old_status` (`role_id`,`tracker_id`,`old_status_id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=145 ;
+
+--
+-- テーブルのデータをダンプしています `workflows`
+--
+
+INSERT INTO `{prefix}workflows` (`id`, `tracker_id`, `old_status_id`, `new_status_id`, `role_id`) VALUES
+(1, 1, 1, 2, 3),
+(2, 1, 1, 3, 3),
+(3, 1, 1, 4, 3),
+(4, 1, 1, 5, 3),
+(5, 1, 1, 6, 3),
+(6, 1, 2, 1, 3),
+(7, 1, 2, 3, 3),
+(8, 1, 2, 4, 3),
+(9, 1, 2, 5, 3),
+(10, 1, 2, 6, 3),
+(11, 1, 3, 1, 3),
+(12, 1, 3, 2, 3),
+(13, 1, 3, 4, 3),
+(14, 1, 3, 5, 3),
+(15, 1, 3, 6, 3),
+(16, 1, 4, 1, 3),
+(17, 1, 4, 2, 3),
+(18, 1, 4, 3, 3),
+(19, 1, 4, 5, 3),
+(20, 1, 4, 6, 3),
+(21, 1, 5, 1, 3),
+(22, 1, 5, 2, 3),
+(23, 1, 5, 3, 3),
+(24, 1, 5, 4, 3),
+(25, 1, 5, 6, 3),
+(26, 1, 6, 1, 3),
+(27, 1, 6, 2, 3),
+(28, 1, 6, 3, 3),
+(29, 1, 6, 4, 3),
+(30, 1, 6, 5, 3),
+(31, 2, 1, 2, 3),
+(32, 2, 1, 3, 3),
+(33, 2, 1, 4, 3),
+(34, 2, 1, 5, 3),
+(35, 2, 1, 6, 3),
+(36, 2, 2, 1, 3),
+(37, 2, 2, 3, 3),
+(38, 2, 2, 4, 3),
+(39, 2, 2, 5, 3),
+(40, 2, 2, 6, 3),
+(41, 2, 3, 1, 3),
+(42, 2, 3, 2, 3),
+(43, 2, 3, 4, 3),
+(44, 2, 3, 5, 3),
+(45, 2, 3, 6, 3),
+(46, 2, 4, 1, 3),
+(47, 2, 4, 2, 3),
+(48, 2, 4, 3, 3),
+(49, 2, 4, 5, 3),
+(50, 2, 4, 6, 3),
+(51, 2, 5, 1, 3),
+(52, 2, 5, 2, 3),
+(53, 2, 5, 3, 3),
+(54, 2, 5, 4, 3),
+(55, 2, 5, 6, 3),
+(56, 2, 6, 1, 3),
+(57, 2, 6, 2, 3),
+(58, 2, 6, 3, 3),
+(59, 2, 6, 4, 3),
+(60, 2, 6, 5, 3),
+(61, 3, 1, 2, 3),
+(62, 3, 1, 3, 3),
+(63, 3, 1, 4, 3),
+(64, 3, 1, 5, 3),
+(65, 3, 1, 6, 3),
+(66, 3, 2, 1, 3),
+(67, 3, 2, 3, 3),
+(68, 3, 2, 4, 3),
+(69, 3, 2, 5, 3),
+(70, 3, 2, 6, 3),
+(71, 3, 3, 1, 3),
+(72, 3, 3, 2, 3),
+(73, 3, 3, 4, 3),
+(74, 3, 3, 5, 3),
+(75, 3, 3, 6, 3),
+(76, 3, 4, 1, 3),
+(77, 3, 4, 2, 3),
+(78, 3, 4, 3, 3),
+(79, 3, 4, 5, 3),
+(80, 3, 4, 6, 3),
+(81, 3, 5, 1, 3),
+(82, 3, 5, 2, 3),
+(83, 3, 5, 3, 3),
+(84, 3, 5, 4, 3),
+(85, 3, 5, 6, 3),
+(86, 3, 6, 1, 3),
+(87, 3, 6, 2, 3),
+(88, 3, 6, 3, 3),
+(89, 3, 6, 4, 3),
+(90, 3, 6, 5, 3),
+(91, 1, 1, 2, 4),
+(92, 1, 1, 3, 4),
+(93, 1, 1, 4, 4),
+(94, 1, 1, 5, 4),
+(95, 1, 2, 3, 4),
+(96, 1, 2, 4, 4),
+(97, 1, 2, 5, 4),
+(98, 1, 3, 2, 4),
+(99, 1, 3, 4, 4),
+(100, 1, 3, 5, 4),
+(101, 1, 4, 2, 4),
+(102, 1, 4, 3, 4),
+(103, 1, 4, 5, 4),
+(104, 2, 1, 2, 4),
+(105, 2, 1, 3, 4),
+(106, 2, 1, 4, 4),
+(107, 2, 1, 5, 4),
+(108, 2, 2, 3, 4),
+(109, 2, 2, 4, 4),
+(110, 2, 2, 5, 4),
+(111, 2, 3, 2, 4),
+(112, 2, 3, 4, 4),
+(113, 2, 3, 5, 4),
+(114, 2, 4, 2, 4),
+(115, 2, 4, 3, 4),
+(116, 2, 4, 5, 4),
+(117, 3, 1, 2, 4),
+(118, 3, 1, 3, 4),
+(119, 3, 1, 4, 4),
+(120, 3, 1, 5, 4),
+(121, 3, 2, 3, 4),
+(122, 3, 2, 4, 4),
+(123, 3, 2, 5, 4),
+(124, 3, 3, 2, 4),
+(125, 3, 3, 4, 4),
+(126, 3, 3, 5, 4),
+(127, 3, 4, 2, 4),
+(128, 3, 4, 3, 4),
+(129, 3, 4, 5, 4),
+(130, 1, 1, 5, 5),
+(131, 1, 2, 5, 5),
+(132, 1, 3, 5, 5),
+(133, 1, 4, 5, 5),
+(134, 1, 3, 4, 5),
+(135, 2, 1, 5, 5),
+(136, 2, 2, 5, 5),
+(137, 2, 3, 5, 5),
+(138, 2, 4, 5, 5),
+(139, 2, 3, 4, 5),
+(140, 3, 1, 5, 5),
+(141, 3, 2, 5, 5),
+(142, 3, 3, 5, 5),
+(143, 3, 4, 5, 5),
+(144, 3, 3, 4, 5);

--- a/app/Config/sql/postgres.sql.install
+++ b/app/Config/sql/postgres.sql.install
@@ -1,0 +1,1747 @@
+
+CREATE TABLE {prefix}attachments (
+    id integer NOT NULL,
+    container_id integer DEFAULT 0 NOT NULL,
+    container_type character varying(30) NOT NULL,
+    filename character varying(255) NOT NULL,
+    disk_filename character varying(255) NOT NULL,
+    filesize integer DEFAULT 0 NOT NULL,
+    content_type character varying(255) DEFAULT NULL::character varying,
+    digest character varying(40) NOT NULL,
+    downloads integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    created_on timestamp without time zone,
+    description character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}attachments OWNER TO pgadmin;
+
+
+CREATE SEQUENCE {prefix}attachments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}attachments_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}attachments_id_seq OWNED BY attachments.id;
+
+SELECT pg_catalog.setval('{prefix}attachments_id_seq', 1, false);
+
+CREATE TABLE {prefix}auth_sources (
+    id integer NOT NULL,
+    type character varying(30) NOT NULL,
+    name character varying(60) NOT NULL,
+    host character varying(60) DEFAULT NULL::character varying,
+    port integer,
+    account character varying(255) DEFAULT NULL::character varying,
+    account_password character varying(60) DEFAULT NULL::character varying,
+    base_dn character varying(255) DEFAULT NULL::character varying,
+    attr_login character varying(30) DEFAULT NULL::character varying,
+    attr_firstname character varying(30) DEFAULT NULL::character varying,
+    attr_lastname character varying(30) DEFAULT NULL::character varying,
+    attr_mail character varying(30) DEFAULT NULL::character varying,
+    onthefly_register boolean DEFAULT false NOT NULL,
+    tls boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}auth_sources OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}auth_sources_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}auth_sources_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}auth_sources_id_seq OWNED BY auth_sources.id;
+
+SELECT pg_catalog.setval('{prefix}auth_sources_id_seq', 1, false);
+
+CREATE TABLE {prefix}boards (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    name character varying(255) NOT NULL,
+    description character varying(255) DEFAULT NULL::character varying,
+    "position" integer DEFAULT 1,
+    topics_count integer DEFAULT 0 NOT NULL,
+    messages_count integer DEFAULT 0 NOT NULL,
+    last_message_id integer
+);
+
+
+ALTER TABLE public.{prefix}boards OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}boards_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}boards_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}boards_id_seq OWNED BY boards.id;
+
+SELECT pg_catalog.setval('{prefix}boards_id_seq', 1, false);
+
+CREATE TABLE {prefix}changes (
+    id integer NOT NULL,
+    changeset_id integer NOT NULL,
+    action character varying(1) NOT NULL,
+    path character varying(255) NOT NULL,
+    from_path character varying(255) DEFAULT NULL::character varying,
+    from_revision character varying(255) DEFAULT NULL::character varying,
+    revision character varying(255) DEFAULT NULL::character varying,
+    branch character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}changes OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}changes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}changes_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}changes_id_seq OWNED BY changes.id;
+
+SELECT pg_catalog.setval('{prefix}changes_id_seq', 1, false);
+
+CREATE TABLE {prefix}changesets (
+    id integer NOT NULL,
+    repository_id integer NOT NULL,
+    revision character varying(255) NOT NULL,
+    committer character varying(255) DEFAULT NULL::character varying,
+    committed_on timestamp without time zone NOT NULL,
+    comments text,
+    commit_date date,
+    scmid character varying(255) DEFAULT NULL::character varying,
+    user_id integer
+);
+
+
+ALTER TABLE public.{prefix}changesets OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}changesets_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}changesets_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}changesets_id_seq OWNED BY changesets.id;
+
+SELECT pg_catalog.setval('{prefix}changesets_id_seq', 1, false);
+
+CREATE TABLE {prefix}changesets_issues (
+    changeset_id integer NOT NULL,
+    issue_id integer NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}changesets_issues OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}changesets_issues_changeset_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}changesets_issues_changeset_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}changesets_issues_changeset_id_seq OWNED BY changesets_issues.changeset_id;
+
+SELECT pg_catalog.setval('{prefix}changesets_issues_changeset_id_seq', 1, false);
+
+CREATE SEQUENCE {prefix}changesets_issues_issue_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}changesets_issues_issue_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}changesets_issues_issue_id_seq OWNED BY changesets_issues.issue_id;
+
+SELECT pg_catalog.setval('{prefix}changesets_issues_issue_id_seq', 1, false);
+
+CREATE TABLE {prefix}comments (
+    id integer NOT NULL,
+    commented_type character varying(30) NOT NULL,
+    commented_id integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    comments text,
+    created_on timestamp without time zone NOT NULL,
+    updated_on timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}comments OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}comments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}comments_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}comments_id_seq OWNED BY comments.id;
+
+SELECT pg_catalog.setval('{prefix}comments_id_seq', 1, false);
+
+CREATE TABLE {prefix}custom_fields (
+    id integer NOT NULL,
+    type character varying(30) NOT NULL,
+    name character varying(30) NOT NULL,
+    field_format character varying(30) NOT NULL,
+    possible_values text,
+    regexp character varying(255) DEFAULT NULL::character varying,
+    min_length integer DEFAULT 0 NOT NULL,
+    max_length integer DEFAULT 0 NOT NULL,
+    is_required boolean DEFAULT false NOT NULL,
+    is_for_all boolean DEFAULT false NOT NULL,
+    is_filter boolean DEFAULT false NOT NULL,
+    "position" integer DEFAULT 1,
+    searchable boolean DEFAULT false,
+    default_value text
+);
+
+
+ALTER TABLE public.{prefix}custom_fields OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}custom_fields_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}custom_fields_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}custom_fields_id_seq OWNED BY custom_fields.id;
+
+SELECT pg_catalog.setval('{prefix}custom_fields_id_seq', 1, false);
+
+CREATE TABLE {prefix}custom_fields_projects (
+    custom_field_id integer DEFAULT 0 NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}custom_fields_projects OWNER TO pgadmin;
+
+CREATE TABLE {prefix}custom_fields_trackers (
+    custom_field_id integer DEFAULT 0 NOT NULL,
+    tracker_id integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}custom_fields_trackers OWNER TO pgadmin;
+
+CREATE TABLE {prefix}custom_values (
+    id integer NOT NULL,
+    customized_type character varying(30) NOT NULL,
+    customized_id integer DEFAULT 0 NOT NULL,
+    custom_field_id integer DEFAULT 0 NOT NULL,
+    value text
+);
+
+
+ALTER TABLE public.{prefix}custom_values OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}custom_values_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}custom_values_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}custom_values_id_seq OWNED BY custom_values.id;
+
+SELECT pg_catalog.setval('{prefix}custom_values_id_seq', 1, false);
+
+CREATE TABLE {prefix}documents (
+    id integer NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL,
+    category_id integer DEFAULT 0 NOT NULL,
+    title character varying(60) NOT NULL,
+    description text,
+    created_on timestamp without time zone
+);
+
+
+ALTER TABLE public.{prefix}documents OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}documents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}documents_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}documents_id_seq OWNED BY documents.id;
+
+SELECT pg_catalog.setval('{prefix}documents_id_seq', 1, false);
+
+CREATE TABLE {prefix}enabled_modules (
+    id integer NOT NULL,
+    project_id integer,
+    name character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}enabled_modules OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}enabled_modules_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}enabled_modules_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}enabled_modules_id_seq OWNED BY enabled_modules.id;
+
+SELECT pg_catalog.setval('{prefix}enabled_modules_id_seq', 9, false);
+
+CREATE TABLE {prefix}enumerations (
+    id integer NOT NULL,
+    opt character varying(4) NOT NULL,
+    name character varying(30) NOT NULL,
+    "position" integer DEFAULT 1,
+    is_default boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}enumerations OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}enumerations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}enumerations_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}enumerations_id_seq OWNED BY enumerations.id;
+
+SELECT pg_catalog.setval('{prefix}enumerations_id_seq', 10, false);
+
+CREATE TABLE {prefix}issue_categories (
+    id integer NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL,
+    name character varying(30) NOT NULL,
+    assigned_to_id integer
+);
+
+
+ALTER TABLE public.{prefix}issue_categories OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}issue_categories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}issue_categories_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}issue_categories_id_seq OWNED BY issue_categories.id;
+
+SELECT pg_catalog.setval('{prefix}issue_categories_id_seq', 1, false);
+
+CREATE TABLE {prefix}issue_relations (
+    id integer NOT NULL,
+    issue_from_id integer NOT NULL,
+    issue_to_id integer NOT NULL,
+    relation_type character varying(255) NOT NULL,
+    delay integer
+);
+
+
+ALTER TABLE public.{prefix}issue_relations OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}issue_relations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}issue_relations_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}issue_relations_id_seq OWNED BY issue_relations.id;
+
+SELECT pg_catalog.setval('{prefix}issue_relations_id_seq', 1, false);
+
+CREATE TABLE {prefix}issue_statuses (
+    id integer NOT NULL,
+    name character varying(30) NOT NULL,
+    is_closed boolean DEFAULT false NOT NULL,
+    is_default boolean DEFAULT false NOT NULL,
+    "position" integer DEFAULT 1
+);
+
+
+ALTER TABLE public.{prefix}issue_statuses OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}issue_statuses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}issue_statuses_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}issue_statuses_id_seq OWNED BY issue_statuses.id;
+
+SELECT pg_catalog.setval('{prefix}issue_statuses_id_seq', 7, false);
+
+CREATE TABLE {prefix}issues (
+    id integer NOT NULL,
+    tracker_id integer DEFAULT 0 NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL,
+    subject character varying(255) NOT NULL,
+    description text,
+    due_date date,
+    category_id integer,
+    status_id integer DEFAULT 0 NOT NULL,
+    assigned_to_id integer,
+    priority_id integer DEFAULT 0 NOT NULL,
+    fixed_version_id integer,
+    author_id integer DEFAULT 0 NOT NULL,
+    lock_version integer DEFAULT 0 NOT NULL,
+    created_on timestamp without time zone,
+    updated_on timestamp without time zone,
+    start_date date,
+    done_ratio integer DEFAULT 0 NOT NULL,
+    estimated_hours double precision
+);
+
+
+ALTER TABLE public.{prefix}issues OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}issues_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}issues_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}issues_id_seq OWNED BY issues.id;
+
+SELECT pg_catalog.setval('{prefix}issues_id_seq', 4, false);
+
+CREATE TABLE {prefix}journal_details (
+    id integer NOT NULL,
+    journal_id integer DEFAULT 0 NOT NULL,
+    property character varying(30) NOT NULL,
+    prop_key character varying(30) NOT NULL,
+    old_value character varying(255) DEFAULT NULL::character varying,
+    value character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}journal_details OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}journal_details_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}journal_details_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}journal_details_id_seq OWNED BY journal_details.id;
+
+SELECT pg_catalog.setval('{prefix}journal_details_id_seq', 1, false);
+
+CREATE TABLE {prefix}journals (
+    id integer NOT NULL,
+    journalized_id integer DEFAULT 0 NOT NULL,
+    journalized_type character varying(30) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notes text,
+    created_on timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}journals OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}journals_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}journals_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}journals_id_seq OWNED BY journals.id;
+
+SELECT pg_catalog.setval('{prefix}journals_id_seq', 1, false);
+
+CREATE TABLE {prefix}members (
+    id integer NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL,
+    role_id integer DEFAULT 0 NOT NULL,
+    created_on timestamp without time zone,
+    mail_notification boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}members OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}members_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}members_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}members_id_seq OWNED BY members.id;
+
+SELECT pg_catalog.setval('{prefix}members_id_seq', 1, false);
+
+CREATE TABLE {prefix}news (
+    id integer NOT NULL,
+    project_id integer,
+    title character varying(60) NOT NULL,
+    summary character varying(255) DEFAULT NULL::character varying,
+    description text,
+    author_id integer DEFAULT 0 NOT NULL,
+    created_on timestamp without time zone,
+    comments_count integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}news OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}news_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}news_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}news_id_seq OWNED BY news.id;
+
+SELECT pg_catalog.setval('{prefix}news_id_seq', 3, false);
+
+CREATE TABLE {prefix}projects (
+    id integer NOT NULL,
+    name character varying(30) NOT NULL,
+    description text,
+    homepage character varying(255) DEFAULT NULL::character varying,
+    is_public boolean DEFAULT true NOT NULL,
+    parent_id integer,
+    projects_count integer DEFAULT 0,
+    created_on timestamp without time zone,
+    updated_on timestamp without time zone,
+    identifier character varying(20) DEFAULT NULL::character varying,
+    status integer DEFAULT 1 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}projects OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}projects_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}projects_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}projects_id_seq OWNED BY projects.id;
+
+SELECT pg_catalog.setval('{prefix}projects_id_seq', 2, false);
+
+CREATE TABLE {prefix}projects_trackers (
+    project_id integer NOT NULL,
+    tracker_id integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}projects_trackers OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}projects_trackers_project_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}projects_trackers_project_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}projects_trackers_project_id_seq OWNED BY projects_trackers.project_id;
+
+SELECT pg_catalog.setval('{prefix}projects_trackers_project_id_seq', 1, false);
+
+CREATE TABLE {prefix}queries (
+    id integer NOT NULL,
+    project_id integer,
+    name character varying(255) NOT NULL,
+    filters text,
+    user_id integer DEFAULT 0 NOT NULL,
+    is_public boolean DEFAULT false NOT NULL,
+    column_names text
+);
+
+
+ALTER TABLE public.{prefix}queries OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}queries_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}queries_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}queries_id_seq OWNED BY queries.id;
+
+SELECT pg_catalog.setval('{prefix}queries_id_seq', 1, false);
+
+CREATE TABLE {prefix}repositories (
+    id integer NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL,
+    url character varying(255) NOT NULL,
+    login character varying(60) DEFAULT NULL::character varying,
+    password character varying(60) DEFAULT NULL::character varying,
+    root_url character varying(255) DEFAULT NULL::character varying,
+    type character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}repositories OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}repositories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}repositories_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}repositories_id_seq OWNED BY repositories.id;
+
+SELECT pg_catalog.setval('{prefix}repositories_id_seq', 1, false);
+
+CREATE TABLE {prefix}roles (
+    id integer NOT NULL,
+    name character varying(30) NOT NULL,
+    "position" integer DEFAULT 1,
+    assignable boolean DEFAULT true,
+    builtin integer DEFAULT 0 NOT NULL,
+    permissions text
+);
+
+
+ALTER TABLE public.{prefix}roles OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}roles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}roles_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}roles_id_seq OWNED BY roles.id;
+
+SELECT pg_catalog.setval('{prefix}roles_id_seq', 6, false);
+
+CREATE TABLE {prefix}schema_migrations (
+    version character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}schema_migrations OWNER TO pgadmin;
+
+CREATE TABLE {prefix}settings (
+    id integer NOT NULL,
+    name character varying(30) NOT NULL,
+    value text,
+    updated_on timestamp without time zone
+);
+
+
+ALTER TABLE public.{prefix}settings OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}settings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}settings_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}settings_id_seq OWNED BY settings.id;
+
+SELECT pg_catalog.setval('{prefix}settings_id_seq', 1, false);
+
+CREATE TABLE {prefix}time_entries (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    user_id integer NOT NULL,
+    issue_id integer,
+    hours double precision NOT NULL,
+    comments character varying(255) DEFAULT NULL::character varying,
+    activity_id integer NOT NULL,
+    spent_on date NOT NULL,
+    tyear integer NOT NULL,
+    tmonth integer NOT NULL,
+    tweek integer NOT NULL,
+    created_on timestamp without time zone NOT NULL,
+    updated_on timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}time_entries OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}time_entries_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}time_entries_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}time_entries_id_seq OWNED BY time_entries.id;
+
+SELECT pg_catalog.setval('{prefix}time_entries_id_seq', 1, false);
+
+CREATE TABLE {prefix}tokens (
+    id integer NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    action character varying(30) NOT NULL,
+    value character varying(40) NOT NULL,
+    created_on timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}tokens OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}tokens_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}tokens_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}tokens_id_seq OWNED BY tokens.id;
+
+SELECT pg_catalog.setval('{prefix}tokens_id_seq', 5, false);
+
+CREATE TABLE {prefix}trackers (
+    id integer NOT NULL,
+    name character varying(30) NOT NULL,
+    is_in_chlog boolean DEFAULT false NOT NULL,
+    "position" integer DEFAULT 1,
+    is_in_roadmap boolean DEFAULT true NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}trackers OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}trackers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}trackers_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}trackers_id_seq OWNED BY trackers.id;
+
+SELECT pg_catalog.setval('{prefix}trackers_id_seq', 4, false);
+
+CREATE TABLE {prefix}user_preferences (
+    id integer NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    others text,
+    hide_mail boolean DEFAULT false,
+    time_zone character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}user_preferences OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}user_preferences_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}user_preferences_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}user_preferences_id_seq OWNED BY user_preferences.id;
+
+SELECT pg_catalog.setval('{prefix}user_preferences_id_seq', 10, false);
+
+CREATE TABLE {prefix}users (
+    id integer NOT NULL,
+    login character varying(30) NOT NULL,
+    hashed_password character varying(40) NOT NULL,
+    firstname character varying(30) NOT NULL,
+    lastname character varying(30) NOT NULL,
+    mail character varying(60) NOT NULL,
+    mail_notification boolean DEFAULT true NOT NULL,
+    admin boolean DEFAULT false NOT NULL,
+    status integer DEFAULT 1 NOT NULL,
+    last_login_on timestamp without time zone,
+    language character varying(5) DEFAULT NULL::character varying,
+    auth_source_id integer,
+    created_on timestamp without time zone,
+    updated_on timestamp without time zone,
+    type character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}users OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}users_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}users_id_seq OWNED BY users.id;
+
+SELECT pg_catalog.setval('{prefix}users_id_seq', 4, false);
+
+CREATE TABLE {prefix}versions (
+    id integer NOT NULL,
+    project_id integer DEFAULT 0 NOT NULL,
+    name character varying(255) NOT NULL,
+    description character varying(255) DEFAULT NULL::character varying,
+    effective_date date,
+    created_on timestamp without time zone,
+    updated_on timestamp without time zone,
+    wiki_page_title character varying(255) DEFAULT NULL::character varying
+);
+
+
+ALTER TABLE public.{prefix}versions OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}versions_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}versions_id_seq OWNED BY versions.id;
+
+SELECT pg_catalog.setval('{prefix}versions_id_seq', 1, false);
+
+CREATE TABLE {prefix}watchers (
+    id integer NOT NULL,
+    watchable_type character varying(255) NOT NULL,
+    watchable_id integer DEFAULT 0 NOT NULL,
+    user_id integer
+);
+
+
+ALTER TABLE public.{prefix}watchers OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}watchers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}watchers_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}watchers_id_seq OWNED BY watchers.id;
+
+SELECT pg_catalog.setval('{prefix}watchers_id_seq', 1, false);
+
+CREATE TABLE {prefix}wiki_content_versions (
+    id integer NOT NULL,
+    wiki_content_id integer NOT NULL,
+    page_id integer NOT NULL,
+    author_id integer,
+    data bytea,
+    compression character varying(6) DEFAULT NULL::character varying,
+    comments character varying(255) DEFAULT NULL::character varying,
+    updated_on timestamp without time zone NOT NULL,
+    version integer NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}wiki_content_versions OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}wiki_content_versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}wiki_content_versions_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}wiki_content_versions_id_seq OWNED BY wiki_content_versions.id;
+
+SELECT pg_catalog.setval('{prefix}wiki_content_versions_id_seq', 4, false);
+
+CREATE TABLE {prefix}wiki_contents (
+    id integer NOT NULL,
+    page_id integer NOT NULL,
+    author_id integer,
+    text text,
+    comments character varying(255) DEFAULT NULL::character varying,
+    updated_on timestamp without time zone NOT NULL,
+    version integer NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}wiki_contents OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}wiki_contents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}wiki_contents_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}wiki_contents_id_seq OWNED BY wiki_contents.id;
+
+SELECT pg_catalog.setval('{prefix}wiki_contents_id_seq', 3, false);
+
+CREATE TABLE {prefix}wiki_pages (
+    id integer NOT NULL,
+    wiki_id integer NOT NULL,
+    title character varying(255) NOT NULL,
+    created_on timestamp without time zone NOT NULL,
+    protected boolean DEFAULT false NOT NULL,
+    parent_id integer
+);
+
+
+ALTER TABLE public.{prefix}wiki_pages OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}wiki_pages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}wiki_pages_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}wiki_pages_id_seq OWNED BY wiki_pages.id;
+
+SELECT pg_catalog.setval('{prefix}wiki_pages_id_seq', 3, false);
+
+CREATE TABLE {prefix}wiki_redirects (
+    id integer NOT NULL,
+    wiki_id integer NOT NULL,
+    title character varying(255) DEFAULT NULL::character varying,
+    redirects_to character varying(255) DEFAULT NULL::character varying,
+    created_on timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}wiki_redirects OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}wiki_redirects_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}wiki_redirects_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}wiki_redirects_id_seq OWNED BY wiki_redirects.id;
+
+SELECT pg_catalog.setval('{prefix}wiki_redirects_id_seq', 1, false);
+
+CREATE TABLE {prefix}wikis (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    start_page character varying(255) NOT NULL,
+    status integer DEFAULT 1 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}wikis OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}wikis_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}wikis_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}wikis_id_seq OWNED BY wikis.id;
+
+SELECT pg_catalog.setval('{prefix}wikis_id_seq', 2, false);
+
+CREATE TABLE {prefix}workflows (
+    id integer NOT NULL,
+    tracker_id integer DEFAULT 0 NOT NULL,
+    old_status_id integer DEFAULT 0 NOT NULL,
+    new_status_id integer DEFAULT 0 NOT NULL,
+    role_id integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE public.{prefix}workflows OWNER TO pgadmin;
+
+CREATE SEQUENCE {prefix}workflows_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.{prefix}workflows_id_seq OWNER TO pgadmin;
+
+ALTER SEQUENCE {prefix}workflows_id_seq OWNED BY workflows.id;
+
+SELECT pg_catalog.setval('{prefix}workflows_id_seq', 145, false);
+
+ALTER TABLE {prefix}attachments ALTER COLUMN id SET DEFAULT nextval('attachments_id_seq'::regclass);
+
+ALTER TABLE {prefix}auth_sources ALTER COLUMN id SET DEFAULT nextval('auth_sources_id_seq'::regclass);
+
+ALTER TABLE {prefix}boards ALTER COLUMN id SET DEFAULT nextval('boards_id_seq'::regclass);
+
+ALTER TABLE {prefix}changes ALTER COLUMN id SET DEFAULT nextval('changes_id_seq'::regclass);
+
+ALTER TABLE {prefix}changesets ALTER COLUMN id SET DEFAULT nextval('changesets_id_seq'::regclass);
+
+ALTER TABLE {prefix}changesets_issues ALTER COLUMN changeset_id SET DEFAULT nextval('changesets_issues_changeset_id_seq'::regclass);
+
+ALTER TABLE {prefix}changesets_issues ALTER COLUMN issue_id SET DEFAULT nextval('changesets_issues_issue_id_seq'::regclass);
+
+ALTER TABLE {prefix}comments ALTER COLUMN id SET DEFAULT nextval('comments_id_seq'::regclass);
+
+ALTER TABLE {prefix}custom_fields ALTER COLUMN id SET DEFAULT nextval('custom_fields_id_seq'::regclass);
+
+ALTER TABLE {prefix}custom_values ALTER COLUMN id SET DEFAULT nextval('custom_values_id_seq'::regclass);
+
+ALTER TABLE {prefix}documents ALTER COLUMN id SET DEFAULT nextval('documents_id_seq'::regclass);
+
+ALTER TABLE {prefix}enabled_modules ALTER COLUMN id SET DEFAULT nextval('enabled_modules_id_seq'::regclass);
+
+ALTER TABLE {prefix}enumerations ALTER COLUMN id SET DEFAULT nextval('enumerations_id_seq'::regclass);
+
+ALTER TABLE {prefix}issue_categories ALTER COLUMN id SET DEFAULT nextval('issue_categories_id_seq'::regclass);
+
+ALTER TABLE {prefix}issue_relations ALTER COLUMN id SET DEFAULT nextval('issue_relations_id_seq'::regclass);
+
+ALTER TABLE {prefix}issue_statuses ALTER COLUMN id SET DEFAULT nextval('issue_statuses_id_seq'::regclass);
+
+ALTER TABLE {prefix}issues ALTER COLUMN id SET DEFAULT nextval('issues_id_seq'::regclass);
+
+ALTER TABLE {prefix}journal_details ALTER COLUMN id SET DEFAULT nextval('journal_details_id_seq'::regclass);
+
+ALTER TABLE {prefix}journals ALTER COLUMN id SET DEFAULT nextval('journals_id_seq'::regclass);
+
+ALTER TABLE {prefix}members ALTER COLUMN id SET DEFAULT nextval('members_id_seq'::regclass);
+
+ALTER TABLE {prefix}news ALTER COLUMN id SET DEFAULT nextval('news_id_seq'::regclass);
+
+ALTER TABLE {prefix}projects ALTER COLUMN id SET DEFAULT nextval('projects_id_seq'::regclass);
+
+ALTER TABLE {prefix}projects_trackers ALTER COLUMN project_id SET DEFAULT nextval('projects_trackers_project_id_seq'::regclass);
+
+ALTER TABLE {prefix}queries ALTER COLUMN id SET DEFAULT nextval('queries_id_seq'::regclass);
+
+ALTER TABLE {prefix}repositories ALTER COLUMN id SET DEFAULT nextval('repositories_id_seq'::regclass);
+
+ALTER TABLE {prefix}roles ALTER COLUMN id SET DEFAULT nextval('roles_id_seq'::regclass);
+
+ALTER TABLE {prefix}settings ALTER COLUMN id SET DEFAULT nextval('settings_id_seq'::regclass);
+
+ALTER TABLE {prefix}time_entries ALTER COLUMN id SET DEFAULT nextval('time_entries_id_seq'::regclass);
+
+ALTER TABLE {prefix}tokens ALTER COLUMN id SET DEFAULT nextval('tokens_id_seq'::regclass);
+
+ALTER TABLE {prefix}trackers ALTER COLUMN id SET DEFAULT nextval('trackers_id_seq'::regclass);
+
+ALTER TABLE {prefix}user_preferences ALTER COLUMN id SET DEFAULT nextval('user_preferences_id_seq'::regclass);
+
+ALTER TABLE {prefix}users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+ALTER TABLE {prefix}versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq'::regclass);
+
+ALTER TABLE {prefix}watchers ALTER COLUMN id SET DEFAULT nextval('watchers_id_seq'::regclass);
+
+ALTER TABLE {prefix}wiki_content_versions ALTER COLUMN id SET DEFAULT nextval('wiki_content_versions_id_seq'::regclass);
+
+ALTER TABLE {prefix}wiki_contents ALTER COLUMN id SET DEFAULT nextval('wiki_contents_id_seq'::regclass);
+
+ALTER TABLE {prefix}wiki_pages ALTER COLUMN id SET DEFAULT nextval('wiki_pages_id_seq'::regclass);
+
+ALTER TABLE {prefix}wiki_redirects ALTER COLUMN id SET DEFAULT nextval('wiki_redirects_id_seq'::regclass);
+
+ALTER TABLE {prefix}wikis ALTER COLUMN id SET DEFAULT nextval('wikis_id_seq'::regclass);
+
+ALTER TABLE {prefix}workflows ALTER COLUMN id SET DEFAULT nextval('workflows_id_seq'::regclass);
+
+INSERT INTO {prefix}enabled_modules VALUES (1, 1, 'issue_tracking');
+INSERT INTO {prefix}enabled_modules VALUES (2, 1, 'time_tracking');
+INSERT INTO {prefix}enabled_modules VALUES (3, 1, 'news');
+INSERT INTO {prefix}enabled_modules VALUES (4, 1, 'documents');
+INSERT INTO {prefix}enabled_modules VALUES (5, 1, 'files');
+INSERT INTO {prefix}enabled_modules VALUES (6, 1, 'wiki');
+INSERT INTO {prefix}enabled_modules VALUES (7, 1, 'repository');
+INSERT INTO {prefix}enabled_modules VALUES (8, 1, 'boards');
+
+INSERT INTO {prefix}enumerations VALUES (1, 'DCAT', 'User documentation', 1, false);
+INSERT INTO {prefix}enumerations VALUES (2, 'DCAT', 'Technical documentation', 2, false);
+INSERT INTO {prefix}enumerations VALUES (3, 'IPRI', 'Low', 1, false);
+INSERT INTO {prefix}enumerations VALUES (4, 'IPRI', 'Normal', 2, true);
+INSERT INTO {prefix}enumerations VALUES (5, 'IPRI', 'High', 3, false);
+INSERT INTO {prefix}enumerations VALUES (6, 'IPRI', 'Urgent', 4, false);
+INSERT INTO {prefix}enumerations VALUES (7, 'IPRI', 'Immediate', 5, false);
+INSERT INTO {prefix}enumerations VALUES (8, 'ACTI', 'Design', 1, false);
+INSERT INTO {prefix}enumerations VALUES (9, 'ACTI', 'Development', 2, false);
+
+INSERT INTO {prefix}issue_statuses VALUES (1, 'New', false, true, 1);
+INSERT INTO {prefix}issue_statuses VALUES (2, 'Assigned', false, true, 2);
+INSERT INTO {prefix}issue_statuses VALUES (3, 'Resolved', false, true, 3);
+INSERT INTO {prefix}issue_statuses VALUES (4, 'Feedback', false, true, 4);
+INSERT INTO {prefix}issue_statuses VALUES (5, 'Closed', true, true, 5);
+INSERT INTO {prefix}issue_statuses VALUES (6, 'Rejected', true, true, 6);
+
+INSERT INTO {prefix}issues VALUES (1, 1, 1, 'Sample Ticket', 'Hello candycane users.', NULL, NULL, 1, NULL, 4, NULL, 3, 0, '2009-03-14 10:32:00', '2009-03-14 10:32:00', '2009-03-14', 0, NULL);
+
+
+INSERT INTO {prefix}news VALUES (1, 1, 'Sample News', 'Working fine.', 'Worked
+*YEAH!!*', 3, '2009-03-20 23:25:45', 0);
+
+INSERT INTO {prefix}projects VALUES (1, 'Sample Project', 'Candycane rocks!', '', true, NULL, 0, '2009-03-04 23:09:49', '2009-03-04 23:09:49', 'sampleproject', 1);
+
+INSERT INTO {prefix}projects_trackers VALUES (1, 1);
+INSERT INTO {prefix}projects_trackers VALUES (1, 2);
+INSERT INTO {prefix}projects_trackers VALUES (1, 3);
+
+
+INSERT INTO {prefix}roles VALUES (1, 'Non member', 1, true, 1, '--- 
+- :add_issues
+- :add_issue_notes
+- :save_queries
+- :view_gantt
+- :view_calendar
+- :view_time_entries
+- :comment_news
+- :view_documents
+- :view_wiki_pages
+- :view_wiki_edits
+- :add_messages
+- :view_files
+- :browse_repository
+- :view_changesets
+');
+INSERT INTO {prefix}roles VALUES (2, 'Anonymous', 2, true, 2, '--- 
+- :view_gantt
+- :view_calendar
+- :view_time_entries
+- :view_documents
+- :view_wiki_pages
+- :view_wiki_edits
+- :view_files
+- :browse_repository
+- :view_changesets
+');
+INSERT INTO {prefix}roles VALUES (3, 'Manager', 3, true, 0, '--- 
+- :edit_project
+- :select_project_modules
+- :manage_members
+- :manage_versions
+- :manage_categories
+- :add_issues
+- :edit_issues
+- :manage_issue_relations
+- :add_issue_notes
+- :edit_issue_notes
+- :edit_own_issue_notes
+- :move_issues
+- :delete_issues
+- :manage_public_queries
+- :save_queries
+- :view_gantt
+- :view_calendar
+- :view_issue_watchers
+- :add_issue_watchers
+- :log_time
+- :view_time_entries
+- :edit_time_entries
+- :edit_own_time_entries
+- :manage_news
+- :comment_news
+- :manage_documents
+- :view_documents
+- :manage_files
+- :view_files
+- :manage_wiki
+- :rename_wiki_pages
+- :delete_wiki_pages
+- :view_wiki_pages
+- :view_wiki_edits
+- :edit_wiki_pages
+- :delete_wiki_pages_attachments
+- :protect_wiki_pages
+- :manage_repository
+- :browse_repository
+- :view_changesets
+- :commit_access
+- :manage_boards
+- :add_messages
+- :edit_messages
+- :edit_own_messages
+- :delete_messages
+- :delete_own_messages
+');
+INSERT INTO {prefix}roles VALUES (4, 'Developer', 4, true, 0, '--- 
+- :manage_versions
+- :manage_categories
+- :add_issues
+- :edit_issues
+- :manage_issue_relations
+- :add_issue_notes
+- :save_queries
+- :view_gantt
+- :view_calendar
+- :log_time
+- :view_time_entries
+- :comment_news
+- :view_documents
+- :view_wiki_pages
+- :view_wiki_edits
+- :edit_wiki_pages
+- :delete_wiki_pages
+- :add_messages
+- :edit_own_messages
+- :view_files
+- :manage_files
+- :browse_repository
+- :view_changesets
+- :commit_access
+');
+INSERT INTO {prefix}roles VALUES (5, 'Reporter', 5, true, 0, '--- 
+- :add_issues
+- :add_issue_notes
+- :save_queries
+- :view_gantt
+- :view_calendar
+- :log_time
+- :view_time_entries
+- :comment_news
+- :view_documents
+- :view_wiki_pages
+- :view_wiki_edits
+- :add_messages
+- :edit_own_messages
+- :view_files
+- :browse_repository
+- :view_changesets
+');
+
+INSERT INTO {prefix}schema_migrations VALUES ('1');
+INSERT INTO {prefix}schema_migrations VALUES ('10');
+INSERT INTO {prefix}schema_migrations VALUES ('100');
+INSERT INTO {prefix}schema_migrations VALUES ('101');
+INSERT INTO {prefix}schema_migrations VALUES ('11');
+INSERT INTO {prefix}schema_migrations VALUES ('12');
+INSERT INTO {prefix}schema_migrations VALUES ('13');
+INSERT INTO {prefix}schema_migrations VALUES ('14');
+INSERT INTO {prefix}schema_migrations VALUES ('15');
+INSERT INTO {prefix}schema_migrations VALUES ('16');
+INSERT INTO {prefix}schema_migrations VALUES ('17');
+INSERT INTO {prefix}schema_migrations VALUES ('18');
+INSERT INTO {prefix}schema_migrations VALUES ('19');
+INSERT INTO {prefix}schema_migrations VALUES ('2');
+INSERT INTO {prefix}schema_migrations VALUES ('20');
+INSERT INTO {prefix}schema_migrations VALUES ('21');
+INSERT INTO {prefix}schema_migrations VALUES ('22');
+INSERT INTO {prefix}schema_migrations VALUES ('23');
+INSERT INTO {prefix}schema_migrations VALUES ('24');
+INSERT INTO {prefix}schema_migrations VALUES ('25');
+INSERT INTO {prefix}schema_migrations VALUES ('26');
+INSERT INTO {prefix}schema_migrations VALUES ('27');
+INSERT INTO {prefix}schema_migrations VALUES ('28');
+INSERT INTO {prefix}schema_migrations VALUES ('29');
+INSERT INTO {prefix}schema_migrations VALUES ('3');
+INSERT INTO {prefix}schema_migrations VALUES ('30');
+INSERT INTO {prefix}schema_migrations VALUES ('31');
+INSERT INTO {prefix}schema_migrations VALUES ('32');
+INSERT INTO {prefix}schema_migrations VALUES ('33');
+INSERT INTO {prefix}schema_migrations VALUES ('34');
+INSERT INTO {prefix}schema_migrations VALUES ('35');
+INSERT INTO {prefix}schema_migrations VALUES ('36');
+INSERT INTO {prefix}schema_migrations VALUES ('37');
+INSERT INTO {prefix}schema_migrations VALUES ('38');
+INSERT INTO {prefix}schema_migrations VALUES ('39');
+INSERT INTO {prefix}schema_migrations VALUES ('4');
+INSERT INTO {prefix}schema_migrations VALUES ('40');
+INSERT INTO {prefix}schema_migrations VALUES ('41');
+INSERT INTO {prefix}schema_migrations VALUES ('42');
+INSERT INTO {prefix}schema_migrations VALUES ('43');
+INSERT INTO {prefix}schema_migrations VALUES ('44');
+INSERT INTO {prefix}schema_migrations VALUES ('45');
+INSERT INTO {prefix}schema_migrations VALUES ('46');
+INSERT INTO {prefix}schema_migrations VALUES ('47');
+INSERT INTO {prefix}schema_migrations VALUES ('48');
+INSERT INTO {prefix}schema_migrations VALUES ('49');
+INSERT INTO {prefix}schema_migrations VALUES ('5');
+INSERT INTO {prefix}schema_migrations VALUES ('50');
+INSERT INTO {prefix}schema_migrations VALUES ('51');
+INSERT INTO {prefix}schema_migrations VALUES ('52');
+INSERT INTO {prefix}schema_migrations VALUES ('53');
+INSERT INTO {prefix}schema_migrations VALUES ('54');
+INSERT INTO {prefix}schema_migrations VALUES ('55');
+INSERT INTO {prefix}schema_migrations VALUES ('56');
+INSERT INTO {prefix}schema_migrations VALUES ('57');
+INSERT INTO {prefix}schema_migrations VALUES ('58');
+INSERT INTO {prefix}schema_migrations VALUES ('59');
+INSERT INTO {prefix}schema_migrations VALUES ('6');
+INSERT INTO {prefix}schema_migrations VALUES ('60');
+INSERT INTO {prefix}schema_migrations VALUES ('61');
+INSERT INTO {prefix}schema_migrations VALUES ('62');
+INSERT INTO {prefix}schema_migrations VALUES ('63');
+INSERT INTO {prefix}schema_migrations VALUES ('64');
+INSERT INTO {prefix}schema_migrations VALUES ('65');
+INSERT INTO {prefix}schema_migrations VALUES ('66');
+INSERT INTO {prefix}schema_migrations VALUES ('67');
+INSERT INTO {prefix}schema_migrations VALUES ('68');
+INSERT INTO {prefix}schema_migrations VALUES ('69');
+INSERT INTO {prefix}schema_migrations VALUES ('7');
+INSERT INTO {prefix}schema_migrations VALUES ('70');
+INSERT INTO {prefix}schema_migrations VALUES ('71');
+INSERT INTO {prefix}schema_migrations VALUES ('72');
+INSERT INTO {prefix}schema_migrations VALUES ('73');
+INSERT INTO {prefix}schema_migrations VALUES ('74');
+INSERT INTO {prefix}schema_migrations VALUES ('75');
+INSERT INTO {prefix}schema_migrations VALUES ('76');
+INSERT INTO {prefix}schema_migrations VALUES ('77');
+INSERT INTO {prefix}schema_migrations VALUES ('78');
+INSERT INTO {prefix}schema_migrations VALUES ('79');
+INSERT INTO {prefix}schema_migrations VALUES ('8');
+INSERT INTO {prefix}schema_migrations VALUES ('80');
+INSERT INTO {prefix}schema_migrations VALUES ('81');
+INSERT INTO {prefix}schema_migrations VALUES ('82');
+INSERT INTO {prefix}schema_migrations VALUES ('83');
+INSERT INTO {prefix}schema_migrations VALUES ('84');
+INSERT INTO {prefix}schema_migrations VALUES ('85');
+INSERT INTO {prefix}schema_migrations VALUES ('86');
+INSERT INTO {prefix}schema_migrations VALUES ('87');
+INSERT INTO {prefix}schema_migrations VALUES ('88');
+INSERT INTO {prefix}schema_migrations VALUES ('89');
+INSERT INTO {prefix}schema_migrations VALUES ('9');
+INSERT INTO {prefix}schema_migrations VALUES ('90');
+INSERT INTO {prefix}schema_migrations VALUES ('91');
+INSERT INTO {prefix}schema_migrations VALUES ('92');
+INSERT INTO {prefix}schema_migrations VALUES ('93');
+INSERT INTO {prefix}schema_migrations VALUES ('94');
+INSERT INTO {prefix}schema_migrations VALUES ('95');
+INSERT INTO {prefix}schema_migrations VALUES ('96');
+INSERT INTO {prefix}schema_migrations VALUES ('97');
+INSERT INTO {prefix}schema_migrations VALUES ('98');
+INSERT INTO {prefix}schema_migrations VALUES ('99');
+
+
+INSERT INTO {prefix}tokens VALUES (1, 1, 'feeds', 'D7ukdhHJXK7MTwDELqToVcTHPczo4rbCsLTim0pv', '2009-03-04 23:03:11');
+INSERT INTO {prefix}tokens VALUES (2, 1, 'feeds', 'rV5I24UQkA7AImh0FOYM84eNSpDbsOpTFCRcMort', '2009-03-04 23:03:11');
+INSERT INTO {prefix}tokens VALUES (3, 3, 'feeds', 'Zi1s5C1vyA8TAzMXm2hAAIOD8CveWiT3LSI763Ie', '2009-03-04 23:08:46');
+INSERT INTO {prefix}tokens VALUES (4, 3, 'feeds', 'HxAUNOsdgv1y3m8Y0ilEOpW6P3sQaydgCxcmsHx8', '2009-03-04 23:08:46');
+
+
+INSERT INTO {prefix}trackers VALUES (1, 'Bug', true, 1, false);
+INSERT INTO {prefix}trackers VALUES (2, 'Feature', true, 2, true);
+INSERT INTO {prefix}trackers VALUES (3, 'Support', false, 3, false);
+
+INSERT INTO {prefix}user_preferences VALUES (1, 1, '--- {}
+
+', false, NULL);
+INSERT INTO {prefix}user_preferences VALUES (2, 2, '--- {}
+
+', false, NULL);
+
+
+
+INSERT INTO {prefix}users VALUES (1, 'admin', 'd033e22ae348aeb5660fc2140aec35850c4da997', 'Redmine', 'Admin', 'admin@example.net', true, true, 1, '2009-03-04 23:06:50', 'eng', NULL, '2009-03-04 23:00:57', '2009-03-04 23:06:50', 'User');
+INSERT INTO {prefix}users VALUES (2, '', '', '', 'Anonymous', '', false, false, 0, NULL, 'eng', NULL, '2009-03-04 23:02:30', '2009-03-04 23:02:30', 'AnonymousUser');
+INSERT INTO {prefix}users VALUES (3, 'testuser', 'AWESOME', '', 'Anonymous', 'test@example.com', false, false, 0, NULL, 'eng', NULL, '2009-03-04 23:02:30', '2009-03-04 23:02:30', 'TestUser');
+
+INSERT INTO {prefix}workflows VALUES (1, 1, 1, 2, 3);
+INSERT INTO {prefix}workflows VALUES (2, 1, 1, 3, 3);
+INSERT INTO {prefix}workflows VALUES (3, 1, 1, 4, 3);
+INSERT INTO {prefix}workflows VALUES (4, 1, 1, 5, 3);
+INSERT INTO {prefix}workflows VALUES (5, 1, 1, 6, 3);
+INSERT INTO {prefix}workflows VALUES (6, 1, 2, 1, 3);
+INSERT INTO {prefix}workflows VALUES (7, 1, 2, 3, 3);
+INSERT INTO {prefix}workflows VALUES (8, 1, 2, 4, 3);
+INSERT INTO {prefix}workflows VALUES (9, 1, 2, 5, 3);
+INSERT INTO {prefix}workflows VALUES (10, 1, 2, 6, 3);
+INSERT INTO {prefix}workflows VALUES (11, 1, 3, 1, 3);
+INSERT INTO {prefix}workflows VALUES (12, 1, 3, 2, 3);
+INSERT INTO {prefix}workflows VALUES (13, 1, 3, 4, 3);
+INSERT INTO {prefix}workflows VALUES (14, 1, 3, 5, 3);
+INSERT INTO {prefix}workflows VALUES (15, 1, 3, 6, 3);
+INSERT INTO {prefix}workflows VALUES (16, 1, 4, 1, 3);
+INSERT INTO {prefix}workflows VALUES (17, 1, 4, 2, 3);
+INSERT INTO {prefix}workflows VALUES (18, 1, 4, 3, 3);
+INSERT INTO {prefix}workflows VALUES (19, 1, 4, 5, 3);
+INSERT INTO {prefix}workflows VALUES (20, 1, 4, 6, 3);
+INSERT INTO {prefix}workflows VALUES (21, 1, 5, 1, 3);
+INSERT INTO {prefix}workflows VALUES (22, 1, 5, 2, 3);
+INSERT INTO {prefix}workflows VALUES (23, 1, 5, 3, 3);
+INSERT INTO {prefix}workflows VALUES (24, 1, 5, 4, 3);
+INSERT INTO {prefix}workflows VALUES (25, 1, 5, 6, 3);
+INSERT INTO {prefix}workflows VALUES (26, 1, 6, 1, 3);
+INSERT INTO {prefix}workflows VALUES (27, 1, 6, 2, 3);
+INSERT INTO {prefix}workflows VALUES (28, 1, 6, 3, 3);
+INSERT INTO {prefix}workflows VALUES (29, 1, 6, 4, 3);
+INSERT INTO {prefix}workflows VALUES (30, 1, 6, 5, 3);
+INSERT INTO {prefix}workflows VALUES (31, 2, 1, 2, 3);
+INSERT INTO {prefix}workflows VALUES (32, 2, 1, 3, 3);
+INSERT INTO {prefix}workflows VALUES (33, 2, 1, 4, 3);
+INSERT INTO {prefix}workflows VALUES (34, 2, 1, 5, 3);
+INSERT INTO {prefix}workflows VALUES (35, 2, 1, 6, 3);
+INSERT INTO {prefix}workflows VALUES (36, 2, 2, 1, 3);
+INSERT INTO {prefix}workflows VALUES (37, 2, 2, 3, 3);
+INSERT INTO {prefix}workflows VALUES (38, 2, 2, 4, 3);
+INSERT INTO {prefix}workflows VALUES (39, 2, 2, 5, 3);
+INSERT INTO {prefix}workflows VALUES (40, 2, 2, 6, 3);
+INSERT INTO {prefix}workflows VALUES (41, 2, 3, 1, 3);
+INSERT INTO {prefix}workflows VALUES (42, 2, 3, 2, 3);
+INSERT INTO {prefix}workflows VALUES (43, 2, 3, 4, 3);
+INSERT INTO {prefix}workflows VALUES (44, 2, 3, 5, 3);
+INSERT INTO {prefix}workflows VALUES (45, 2, 3, 6, 3);
+INSERT INTO {prefix}workflows VALUES (46, 2, 4, 1, 3);
+INSERT INTO {prefix}workflows VALUES (47, 2, 4, 2, 3);
+INSERT INTO {prefix}workflows VALUES (48, 2, 4, 3, 3);
+INSERT INTO {prefix}workflows VALUES (49, 2, 4, 5, 3);
+INSERT INTO {prefix}workflows VALUES (50, 2, 4, 6, 3);
+INSERT INTO {prefix}workflows VALUES (51, 2, 5, 1, 3);
+INSERT INTO {prefix}workflows VALUES (52, 2, 5, 2, 3);
+INSERT INTO {prefix}workflows VALUES (53, 2, 5, 3, 3);
+INSERT INTO {prefix}workflows VALUES (54, 2, 5, 4, 3);
+INSERT INTO {prefix}workflows VALUES (55, 2, 5, 6, 3);
+INSERT INTO {prefix}workflows VALUES (56, 2, 6, 1, 3);
+INSERT INTO {prefix}workflows VALUES (57, 2, 6, 2, 3);
+INSERT INTO {prefix}workflows VALUES (58, 2, 6, 3, 3);
+INSERT INTO {prefix}workflows VALUES (59, 2, 6, 4, 3);
+INSERT INTO {prefix}workflows VALUES (60, 2, 6, 5, 3);
+INSERT INTO {prefix}workflows VALUES (61, 3, 1, 2, 3);
+INSERT INTO {prefix}workflows VALUES (62, 3, 1, 3, 3);
+INSERT INTO {prefix}workflows VALUES (63, 3, 1, 4, 3);
+INSERT INTO {prefix}workflows VALUES (64, 3, 1, 5, 3);
+INSERT INTO {prefix}workflows VALUES (65, 3, 1, 6, 3);
+INSERT INTO {prefix}workflows VALUES (66, 3, 2, 1, 3);
+INSERT INTO {prefix}workflows VALUES (67, 3, 2, 3, 3);
+INSERT INTO {prefix}workflows VALUES (68, 3, 2, 4, 3);
+INSERT INTO {prefix}workflows VALUES (69, 3, 2, 5, 3);
+INSERT INTO {prefix}workflows VALUES (70, 3, 2, 6, 3);
+INSERT INTO {prefix}workflows VALUES (71, 3, 3, 1, 3);
+INSERT INTO {prefix}workflows VALUES (72, 3, 3, 2, 3);
+INSERT INTO {prefix}workflows VALUES (73, 3, 3, 4, 3);
+INSERT INTO {prefix}workflows VALUES (74, 3, 3, 5, 3);
+INSERT INTO {prefix}workflows VALUES (75, 3, 3, 6, 3);
+INSERT INTO {prefix}workflows VALUES (76, 3, 4, 1, 3);
+INSERT INTO {prefix}workflows VALUES (77, 3, 4, 2, 3);
+INSERT INTO {prefix}workflows VALUES (78, 3, 4, 3, 3);
+INSERT INTO {prefix}workflows VALUES (79, 3, 4, 5, 3);
+INSERT INTO {prefix}workflows VALUES (80, 3, 4, 6, 3);
+INSERT INTO {prefix}workflows VALUES (81, 3, 5, 1, 3);
+INSERT INTO {prefix}workflows VALUES (82, 3, 5, 2, 3);
+INSERT INTO {prefix}workflows VALUES (83, 3, 5, 3, 3);
+INSERT INTO {prefix}workflows VALUES (84, 3, 5, 4, 3);
+INSERT INTO {prefix}workflows VALUES (85, 3, 5, 6, 3);
+INSERT INTO {prefix}workflows VALUES (86, 3, 6, 1, 3);
+INSERT INTO {prefix}workflows VALUES (87, 3, 6, 2, 3);
+INSERT INTO {prefix}workflows VALUES (88, 3, 6, 3, 3);
+INSERT INTO {prefix}workflows VALUES (89, 3, 6, 4, 3);
+INSERT INTO {prefix}workflows VALUES (90, 3, 6, 5, 3);
+INSERT INTO {prefix}workflows VALUES (91, 1, 1, 2, 4);
+INSERT INTO {prefix}workflows VALUES (92, 1, 1, 3, 4);
+INSERT INTO {prefix}workflows VALUES (93, 1, 1, 4, 4);
+INSERT INTO {prefix}workflows VALUES (94, 1, 1, 5, 4);
+INSERT INTO {prefix}workflows VALUES (95, 1, 2, 3, 4);
+INSERT INTO {prefix}workflows VALUES (96, 1, 2, 4, 4);
+INSERT INTO {prefix}workflows VALUES (97, 1, 2, 5, 4);
+INSERT INTO {prefix}workflows VALUES (98, 1, 3, 2, 4);
+INSERT INTO {prefix}workflows VALUES (99, 1, 3, 4, 4);
+INSERT INTO {prefix}workflows VALUES (100, 1, 3, 5, 4);
+INSERT INTO {prefix}workflows VALUES (101, 1, 4, 2, 4);
+INSERT INTO {prefix}workflows VALUES (102, 1, 4, 3, 4);
+INSERT INTO {prefix}workflows VALUES (103, 1, 4, 5, 4);
+INSERT INTO {prefix}workflows VALUES (104, 2, 1, 2, 4);
+INSERT INTO {prefix}workflows VALUES (105, 2, 1, 3, 4);
+INSERT INTO {prefix}workflows VALUES (106, 2, 1, 4, 4);
+INSERT INTO {prefix}workflows VALUES (107, 2, 1, 5, 4);
+INSERT INTO {prefix}workflows VALUES (108, 2, 2, 3, 4);
+INSERT INTO {prefix}workflows VALUES (109, 2, 2, 4, 4);
+INSERT INTO {prefix}workflows VALUES (110, 2, 2, 5, 4);
+INSERT INTO {prefix}workflows VALUES (111, 2, 3, 2, 4);
+INSERT INTO {prefix}workflows VALUES (112, 2, 3, 4, 4);
+INSERT INTO {prefix}workflows VALUES (113, 2, 3, 5, 4);
+INSERT INTO {prefix}workflows VALUES (114, 2, 4, 2, 4);
+INSERT INTO {prefix}workflows VALUES (115, 2, 4, 3, 4);
+INSERT INTO {prefix}workflows VALUES (116, 2, 4, 5, 4);
+INSERT INTO {prefix}workflows VALUES (117, 3, 1, 2, 4);
+INSERT INTO {prefix}workflows VALUES (118, 3, 1, 3, 4);
+INSERT INTO {prefix}workflows VALUES (119, 3, 1, 4, 4);
+INSERT INTO {prefix}workflows VALUES (120, 3, 1, 5, 4);
+INSERT INTO {prefix}workflows VALUES (121, 3, 2, 3, 4);
+INSERT INTO {prefix}workflows VALUES (122, 3, 2, 4, 4);
+INSERT INTO {prefix}workflows VALUES (123, 3, 2, 5, 4);
+INSERT INTO {prefix}workflows VALUES (124, 3, 3, 2, 4);
+INSERT INTO {prefix}workflows VALUES (125, 3, 3, 4, 4);
+INSERT INTO {prefix}workflows VALUES (126, 3, 3, 5, 4);
+INSERT INTO {prefix}workflows VALUES (127, 3, 4, 2, 4);
+INSERT INTO {prefix}workflows VALUES (128, 3, 4, 3, 4);
+INSERT INTO {prefix}workflows VALUES (129, 3, 4, 5, 4);
+INSERT INTO {prefix}workflows VALUES (130, 1, 1, 5, 5);
+INSERT INTO {prefix}workflows VALUES (131, 1, 2, 5, 5);
+INSERT INTO {prefix}workflows VALUES (132, 1, 3, 5, 5);
+INSERT INTO {prefix}workflows VALUES (133, 1, 4, 5, 5);
+INSERT INTO {prefix}workflows VALUES (134, 1, 3, 4, 5);
+INSERT INTO {prefix}workflows VALUES (135, 2, 1, 5, 5);
+INSERT INTO {prefix}workflows VALUES (136, 2, 2, 5, 5);
+INSERT INTO {prefix}workflows VALUES (137, 2, 3, 5, 5);
+INSERT INTO {prefix}workflows VALUES (138, 2, 4, 5, 5);
+INSERT INTO {prefix}workflows VALUES (139, 2, 3, 4, 5);
+INSERT INTO {prefix}workflows VALUES (140, 3, 1, 5, 5);
+INSERT INTO {prefix}workflows VALUES (141, 3, 2, 5, 5);
+INSERT INTO {prefix}workflows VALUES (142, 3, 3, 5, 5);
+INSERT INTO {prefix}workflows VALUES (143, 3, 4, 5, 5);
+INSERT INTO {prefix}workflows VALUES (144, 3, 3, 4, 5);
+
+
+ALTER TABLE ONLY {prefix}attachments
+    ADD CONSTRAINT attachments_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}auth_sources
+    ADD CONSTRAINT auth_sources_pkey PRIMARY KEY (id);
+
+
+ALTER TABLE ONLY {prefix}boards
+    ADD CONSTRAINT boards_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}changes
+    ADD CONSTRAINT changes_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}changesets
+    ADD CONSTRAINT changesets_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}comments
+    ADD CONSTRAINT comments_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}custom_fields
+    ADD CONSTRAINT custom_fields_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}custom_values
+    ADD CONSTRAINT custom_values_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}documents
+    ADD CONSTRAINT documents_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}enabled_modules
+    ADD CONSTRAINT enabled_modules_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}enumerations
+    ADD CONSTRAINT enumerations_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}issue_categories
+    ADD CONSTRAINT issue_categories_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}issue_relations
+    ADD CONSTRAINT issue_relations_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}issue_statuses
+    ADD CONSTRAINT issue_statuses_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}issues
+    ADD CONSTRAINT issues_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}journal_details
+    ADD CONSTRAINT journal_details_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}journals
+    ADD CONSTRAINT journals_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}members
+    ADD CONSTRAINT members_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}news
+    ADD CONSTRAINT news_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}projects
+    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}queries
+    ADD CONSTRAINT queries_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}repositories
+    ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}roles
+    ADD CONSTRAINT roles_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+ALTER TABLE ONLY {prefix}settings
+    ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}time_entries
+    ADD CONSTRAINT time_entries_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}tokens
+    ADD CONSTRAINT tokens_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}trackers
+    ADD CONSTRAINT trackers_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}user_preferences
+    ADD CONSTRAINT user_preferences_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}versions
+    ADD CONSTRAINT versions_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}watchers
+    ADD CONSTRAINT watchers_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}wiki_content_versions
+    ADD CONSTRAINT wiki_content_versions_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}wiki_contents
+    ADD CONSTRAINT wiki_contents_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}wiki_pages
+    ADD CONSTRAINT wiki_pages_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}wiki_redirects
+    ADD CONSTRAINT wiki_redirects_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}wikis
+    ADD CONSTRAINT wikis_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY {prefix}workflows
+    ADD CONSTRAINT workflows_pkey PRIMARY KEY (id);
+
+CREATE INDEX {prefix}boards_project_id ON boards USING btree (project_id);
+CREATE INDEX {prefix}changesets_changeset_id ON changes USING btree (changeset_id);
+CREATE UNIQUE INDEX {prefix}changesets_issues_ids ON changesets_issues USING btree (changeset_id, issue_id);
+CREATE UNIQUE INDEX {prefix}changesets_repos_rev ON changesets USING btree (repository_id, revision);
+CREATE INDEX {prefix}custom_values_customized ON custom_values USING btree (customized_type, customized_id);
+CREATE INDEX {prefix}documents_project_id ON documents USING btree (project_id);
+CREATE INDEX {prefix}enabled_modules_project_id ON enabled_modules USING btree (project_id);
+CREATE INDEX {prefix}issue_categories_project_id ON issue_categories USING btree (project_id);
+CREATE INDEX {prefix}issues_project_id ON issues USING btree (project_id);
+CREATE INDEX {prefix}journal_details_journal_id ON journal_details USING btree (journal_id);
+CREATE INDEX {prefix}journals_journalized_id ON journals USING btree (journalized_id, journalized_type);
+CREATE INDEX {prefix}news_project_id ON news USING btree (project_id);
+CREATE INDEX {prefix}projects_trackers_project_id ON projects_trackers USING btree (project_id);
+CREATE INDEX {prefix}time_entries_issue_id ON time_entries USING btree (issue_id);
+CREATE INDEX {prefix}time_entries_project_id ON time_entries USING btree (project_id);
+CREATE INDEX {prefix}versions_project_id ON versions USING btree (project_id);
+CREATE INDEX {prefix}wiki_content_versions_wcid ON wiki_content_versions USING btree (wiki_content_id);
+CREATE INDEX {prefix}wiki_contents_page_id ON wiki_contents USING btree (page_id);
+CREATE INDEX {prefix}wiki_pages_wiki_id_title ON wiki_pages USING btree (wiki_id, title);
+CREATE INDEX {prefix}wiki_redirects_wiki_id_title ON wiki_redirects USING btree (wiki_id, title);
+CREATE INDEX {prefix}wikis_project_id ON wikis USING btree (project_id);
+CREATE INDEX {prefix}wkfs_role_tracker_old_status ON workflows USING btree (role_id, tracker_id, old_status_id);

--- a/app/Plugin/CcInstall/View/CcInstall/database.ctp
+++ b/app/Plugin/CcInstall/View/CcInstall/database.ctp
@@ -7,8 +7,8 @@
         echo $this->Form->input('Install.host', array('label' => 'Host', 'value' => 'localhost'));
         echo $this->Form->input('Install.login', array('label' => 'User / Login', 'value' => 'root'));
         echo $this->Form->input('Install.password', array('label' => 'Password'));
-        echo $this->Form->input('Install.database', array('label' => __('Exsisting database name'), 'value' => 'candycane'));
-        echo $this->Form->input('Install.prefix', array('label' => __('Prefix for table name.(if you need)'), 'value' => '', 'disabled' => 'disabled'));
+        echo $this->Form->input('Install.database', array('label' => __('Existing database name'), 'value' => 'candycane'));
+        echo $this->Form->input('Install.prefix', array('label' => __('Prefix for table name.(only for mysql, if you need)'), 'value' => ''));
         echo $this->Form->end(__('Build database'));
     ?>
 </div>


### PR DESCRIPTION
Enable the table prefix in the installation page.
Created mysql.sql.install & postgres.sql.install to serve as templates.

Code tested with mysql and success.
