### PR TITLE
fix attachment description #491

### DIFF
--- a/app/Controller/IssuesController.php
+++ b/app/Controller/IssuesController.php
@@ -386,7 +386,11 @@ class IssuesController extends AppController
 
             if (empty($this->Issue->validationErrors)) {
                 if (!empty($this->request->params['form'])) {
-                    $this->Issue->attach_files($this->request->params['form'], $this->current_user);
+                    $attachments = array_merge(
+                        $this->request->params['form'],
+                        array('attachments_description' => $this->request->data['attachments_description'])
+                    );
+                    $this->Issue->attach_files($attachments, $this->current_user);
                 }
 
                 $event = new CakeEvent(


### PR DESCRIPTION
チケットの付属ファイル説明が登録できないバグとりあえず修正しました。

[facebook](https://www.facebook.com/groups/candycane.dev/permalink/368226709985836) で上がってた方法だと、Behaviorに渡るパラメータが変わるので View / JS / Behavior を修正しないとだめそうでちょっと今やれないのでとりあえずこれでどうでしょうか?
