### PR TITLE
Function split() is deprecated in PHP 5.3.0

### DIFF
--- a/app/Model/MimeType.php
+++ b/app/Model/MimeType.php
@@ -66,7 +66,7 @@ class MimeType {
  */
 	public function __construct() {
 		foreach ($this->MIME_TYPES as $type => $exts) {
-			foreach (split(',', $exts) as $ext) {
+			foreach (explode(',', $exts) as $ext) {
 				$this->EXTENSIONS[trim($ext)] = $type;
 			}
 		}
@@ -99,7 +99,7 @@ class MimeType {
 	public function main_mimetype_of($name) {
 		$mimetype = $this->of($name);
 		if ($mimetype) {
-			return array_shift(split('/', $mimetype));
+			return array_shift(explode('/', $mimetype));
 		}
 		return null;
 	}


### PR DESCRIPTION
http://de3.php.net/split

Updated the "split" function:

from: split to explode
