### PR TITLE
fix: validation for project identifier

### DIFF
--- a/app/Model/Project.php
+++ b/app/Model/Project.php
@@ -111,7 +111,7 @@ class Project extends AppModel {
 		$this->validate = array(
 			'identifier' => array(
 				'length' => array(
-					'rule' => '/[a-z0-9\-]{2,20}/',
+					'rule' => '/^[a-z0-9\-]{2,20}$/',
 					'message' => __('Identifier must be between 2 and 20 characters, containing only letters, numbers and dashes.'),
 				),
 			)


### PR DESCRIPTION
identifier must be between 2 and 20 characters, containing only letters,
numbers and dashes.

the actual regexp `/[a-z0-9\-]{2,20}/` returns true on:

```
EXAMPLE-example
example-EXAMPLE
```

the new regexp fix it. If you insert upper case letters on the id, then, when you want to watch it, it returns not found.