### PR TITLE
Fix bulk move of issues and replace cakeError to Exceptions

### DIFF
--- a/app/Controller/IssuesController.php
+++ b/app/Controller/IssuesController.php
@@ -381,7 +381,7 @@ class IssuesController extends AppController
             $save_data = $event->data['issue'];
 
             if (!$this->Issue->save($save_data) && empty($this->Issue->validationErrors)) {
-                return $this->cakeError('error', array('message' => 'Can not save Issue.'));
+                throw new InternalErrorException('Can not save Issue.');
             }
 
             if (empty($this->Issue->validationErrors)) {
@@ -441,7 +441,7 @@ class IssuesController extends AppController
     {
         static $UPDATABLE_ATTRS_ON_TRANSITION = array('status_id', 'assigned_to_id', 'fixed_version_id', 'done_ratio');
         if (empty($this->request->params['issue_id'])) {
-            return $this->cakeError('error', array('message' => "Not exists issue."));
+            throw new BadRequestException("Not exists issue.");
         }
         $issue = $this->_find_issue($this->request->params['issue_id']);
         if (empty($this->_project)) {
@@ -731,7 +731,7 @@ class IssuesController extends AppController
         } elseif (!empty($this->request->data['Issue']['ids'])) {
             $issue_ids = $this->request->data['Issue']['ids'];
         } else {
-            return $this->cakeError('error', array('message' => "Not exists issue."));
+            throw new BadRequestException("Not exists issue.");
         }
 
         if (!is_array($issue_ids)) {
@@ -740,7 +740,7 @@ class IssuesController extends AppController
         $allowed_projects = array();
         $issues = $this->Issue->find('all', array('conditions' => array('Issue.id' => $issue_ids)));
         if (empty($issues)) {
-            return $this->cakeError('error', array('message' => "Not exists issue."));
+            throw new NotFoundException("Not exists issue.");
         }
 
         // find projects to which the user is allowed to move the issue
@@ -756,7 +756,7 @@ class IssuesController extends AppController
             }
         }
         if (!array_key_exists($issues[0]['Issue']['project_id'], $allowed_projects)) {
-            return $this->cakeError('error', array('message' => "Permission deny."));
+            throw new UnauthorizedException("Permission deny.");
         }
         if ($this->RequestHandler->isPost() && !$this->RequestHandler->isAjax()) {
             $move_count = 0;
@@ -811,7 +811,7 @@ class IssuesController extends AppController
         } elseif (!empty($this->request->data['Issue']['ids'])) {
             $issue_ids = $this->request->data['Issue']['ids'];
         } else {
-            return $this->cakeError('error', array('message' => "Not exists issue."));
+            throw new BadRequestException("Not exists issue.");
         }
 
         if (!is_array($issue_ids)) {
@@ -819,7 +819,7 @@ class IssuesController extends AppController
         }
         $issues = $this->Issue->find('all', array('conditions' => array('Issue.id' => $issue_ids)));
         if (empty($issues)) {
-            return $this->cakeError('error', array('message' => "Not exists issue."));
+            throw new NotFoundException("Not exists issue.");
         }
 
         $this->request->params['project_id'] = $issues[0]['Project']['identifier'];
@@ -1135,7 +1135,7 @@ class IssuesController extends AppController
             $project = $projects[0];
         } else {
             // @TODO: let users bulk edit/move/destroy issues from different projects
-            $this->cakeError('Can not bulk edit/move/destroy issues from different projects');
+            throw new BadRequestException('Can not bulk edit/move/destroy issues from different projects');
         }
         return $issues;
     }

--- a/app/Controller/IssuesController.php
+++ b/app/Controller/IssuesController.php
@@ -730,6 +730,8 @@ class IssuesController extends AppController
             $issue_ids = $this->request->params['url']['ids'];
         } elseif (!empty($this->request->data['Issue']['ids'])) {
             $issue_ids = $this->request->data['Issue']['ids'];
+        } elseif (!empty($this->request->query['ids'])) {
+            $issue_ids = $this->request->query['ids'];
         } else {
             throw new BadRequestException("Not exists issue.");
         }

--- a/app/Controller/TimelogController.php
+++ b/app/Controller/TimelogController.php
@@ -209,7 +209,7 @@ class TimelogController extends AppController
             throw new NotFoundException();
         }
         if (!$this->TimeEntry->is_editable_by($this->current_user, $this->_project)) {
-            $this->cakeError('error403');
+            throw new ForbiddenException('error403');
         }
         if ($this->TimeEntry->delete()) {
             $this->Session->setFlash(__('Successful deletion.'), 'default', array('class' => 'flash flash_notice'));

--- a/app/Model/Behavior/ActivityProviderBehavior.php
+++ b/app/Model/Behavior/ActivityProviderBehavior.php
@@ -145,7 +145,7 @@ class ActivityProviderBehavior extends ModelBehavior {
 
 		$provider_options = $this->settings[$event_type][$Model->alias];
 		if (empty($provider_options)) {
-			return $this->cakeError('error', array('message' => "Can not provide $event_type events."));
+			throw new BadRequestException("Can not provide $event_type events.");
 		}
 		$scope_options = array();
 		$cond = new Condition();
@@ -231,7 +231,7 @@ class Condition {
 		} elseif(is_string($condition)) {
 			$this->conditions[] = array($condition);
 		} else {
-			return $this->cakeError('error', array('message'=>"Unsupported condition."));
+			throw new BadRequestException("Unsupported condition.");
 		}
 	}
 }

--- a/app/Model/Issue.php
+++ b/app/Model/Issue.php
@@ -570,7 +570,7 @@ class Issue extends AppModel
 #  
   function all_dependent_issues() {
     // Move to IssueRelation
-    $this->cakeError('error404');
+    throw new NotFoundException('error404');
   }
 #  
   # Returns an array of issues that duplicate this one

--- a/app/Model/Project.php
+++ b/app/Model/Project.php
@@ -259,7 +259,7 @@ class Project extends AppModel {
  */
 	public function visible_by($user = false) {
 		if (empty($user)) {
-			return $this->cakeError('error', "Argument Exception.");
+			throw new InternalErrorException("Argument Exception.");
 		}
 		if (isset($user['admin']) && $user['admin']) {
 			return array('Project.status' => PROJECT_STATUS_ACTIVE);

--- a/app/Model/Role.php
+++ b/app/Model/Role.php
@@ -104,14 +104,14 @@ class Role extends AppModel {
   function non_member_allowed_to($permission) {
     $non_member = $this->non_member();
     if(empty($non_member)) {
-      $this->cakeError('error', array('message'=>'Missing non-member builtin role.'));
+      throw new BadRequestException('Missing non-member builtin role.');
     }
     return $this->is_allowed_to($non_member, $permission);
   }
   function anonymous_allowed_to($permission) {
     $anonymous = $this->anonymous();
     if(empty($anonymous)) {
-      $this->cakeError('error', array('message'=>'Missing non-member builtin role.'));
+      throw new BadRequestException('Missing non-member builtin role.');
     }
     return $this->is_allowed_to($anonymous, $permission);
   }


### PR DESCRIPTION
Request for bulk move contains "ids" query parameter, so code finding
issue ids should also scan this parameter.

This fixes #279

---

Replace cakeError method with throwing Exceptions.

Since version 2.0 of CakePHP using cakeError() should be replaced with
throwing Exceptions (http://book.cakephp.org/2.0/en/development/errors.html).

List of available exceptions:
http://book.cakephp.org/2.0/en/development/exceptions.html#built-in-exceptions-for-cakephp