### PR TITLE
Add unique id to changelog checkbox tracker element and replace "label" for "div"

### DIFF
--- a/app/View/Elements/projects/sidebar/changelog.ctp
+++ b/app/View/Elements/projects/sidebar/changelog.ctp
@@ -2,9 +2,9 @@
 <h3><?php echo __('Change log') ?></h3>
 
 <?php foreach($trackers as $tracker): ?>
-  <label><?php echo $this->Form->input('tracker_ids[]', array('type'=>'checkbox', 'value'=>$tracker['Tracker']['id'], /* @selected_tracker_ids.include? tracker.id.to_s */ 'label'=>$tracker['Tracker']['name'],
+  <div><?php echo $this->Form->input('tracker_ids[]', array('type'=>'checkbox', 'value'=>$tracker['Tracker']['id'], /* @selected_tracker_ids.include? tracker.id.to_s */ 'label'=>$tracker['Tracker']['name'],
     'id' => 'tracker-'.$tracker['Tracker']['id'])) ?>
-  </label><br />
+  </div> <br />
 <?php endforeach ?>
 <p><?php echo $this->Form->submit(__('Apply'), array('class' => 'button-small')) ?></p>
 <?php echo $this->Form->end() ?>

--- a/app/View/Elements/projects/sidebar/changelog.ctp
+++ b/app/View/Elements/projects/sidebar/changelog.ctp
@@ -1,7 +1,9 @@
 <?php echo $this->Form->create() ?>
 <h3><?php echo __('Change log') ?></h3>
+
 <?php foreach($trackers as $tracker): ?>
-  <label><?php echo $this->Form->input('tracker_ids[]', array('type'=>'checkbox', 'value'=>$tracker['Tracker']['id'], /* @selected_tracker_ids.include? tracker.id.to_s */ 'label'=>$tracker['Tracker']['name'])) ?>
+  <label><?php echo $this->Form->input('tracker_ids[]', array('type'=>'checkbox', 'value'=>$tracker['Tracker']['id'], /* @selected_tracker_ids.include? tracker.id.to_s */ 'label'=>$tracker['Tracker']['name'],
+    'id' => 'tracker-'.$tracker['Tracker']['id'])) ?>
   </label><br />
 <?php endforeach ?>
 <p><?php echo $this->Form->submit(__('Apply'), array('class' => 'button-small')) ?></p>
@@ -11,4 +13,3 @@
 <?php foreach($versions as $version): ?>
 <?php echo $this->Html->link($version['name'], '#'.$version['name']) ?><br />
 <?php endforeach ?>
-

--- a/app/webroot/css/application.css
+++ b/app/webroot/css/application.css
@@ -273,13 +273,8 @@ text-align: left;
 width: 270px;
 }
 
-div.checkbox input[type="checkbox"] {
-	float: left;
-}
-
 div.checkbox label {
 	margin-left: 0px;
-	float: left;
 	width: auto;
 }
 


### PR DESCRIPTION
**Add unique id to changelog checkbox tracker element**

Without this all checkboxes have same id. Labels' "for" attributes point to
all checkboxes and after click on any label always first was checked.

This applies to http://< url >/candycane/projects/< project >/changelog

---

**Replace element "label" for "div" in sidebar/changelog.ctp**

Element "label" should not be used for grouping other HTML elements:
https://www.w3.org/TR/html5/forms.html#the-label-element

This also removes unnecessary float on checkboxes.